### PR TITLE
Issue: #110 Add a visual indicator on the All Posts screen when a title or description is too long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 .travis.yml
 .svn
 
+# IDE #
+#######
+.idea/
+.idea/vcs.xml
 
 # OS #
 ######

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ So you'd like to contribute to an open source project? You're awesome!
 - [Reporting bugs](#reporting-bugs)
 - [Feature ideas](#feature-ideas)
 - [Contributing code](#contributing-code)
-- [Improving docs](#improving-docs)
+- [Translating](#translating)
 
 
 ## Reporting bugs
@@ -122,32 +122,31 @@ A couple of notes:
 
 ### Style guides
 
+All in Code should follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [WordPress Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/).
+
 #### PHP style guide
 
-Most of our PHP code follows [**PSR-2**](http://www.php-fig.org/psr/psr-2/), *not* WordPress coding standards. This is deliberate, see [#698](https://github.com/versionpress/versionpress/issues/698). Basically, it's mainly because most of VersionPress is a relatively separate, object oriented system developed recently, where anything but PSR-2 doesn't feel right.
+[WordPress PHP Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/)
 
-There are a couple of cases where some parts of our code do not adhere to PSR-2 strictly:
+[WordPress PHP Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/)
 
-- **Code interacting with WordPress** (hooking into it, providing global functions etc.) follows some of WP conventions. For example, global functions are called like `vp_register_hooks()`, not `registerHooks()`.
-- **WP-CLI commands** use filenames similar to the built-in commands, so for instance `VPCommand` lives in a `vp.php` file, not `VPCommand.php`.
+There are tools out there for apps like Netbeans and PHPStorm to apply WordPress Coding Standards.
 
-Generally, try to follow what's already in place. The project ships with PhpStorm settings, `.editorconfig` etc. so if you use PhpStorm as recommended, it should serve as a good guidance. 
 
 #### JavaScript style guide
 
-The styleguide is under construction. :construction:
+[WordPress Javascript Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/)
+
+[WordPress Javascript Documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/)
 
 
-### Get help
 
-Feel free to reach the devs in the [Gitter room](https://gitter.im/versionpress/versionpress) if you need help with anything.
+## Translating
 
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/versionpress/versionpress)
+We would love your help translating the project into your language. [Translations](https://translate.wordpress.org/projects/wp-plugins/all-in-one-seo-pack)
 
 
-## Improving docs
-
-Documentation contributions coming soon.
+*more instructions coming soon
 
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# Contributing to All in One SEO Pack
+
+So you'd like to contribute to an open source project? You're awesome!
+
+- [Reporting bugs](#reporting-bugs)
+- [Feature ideas](#feature-ideas)
+- [Contributing code](#contributing-code)
+- [Improving docs](#improving-docs)
+
+
+## Reporting bugs
+
+1. Support issues (white screen of death, plugin/theme conflict, post meta or titles not showing up, etc.) should go to the [**support forums**](http://semperplugins.com/support/). Make sure you're reporting a true AIOSEOP issue here. First do some [basic debugging](http://semperplugins.com/faqs/how-to-troubleshoot-issues-with-our-plugins/).
+2. [**Search** the issues](https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues) first.
+3. [Open a new issue](https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/new).
+
+What makes the issue really helpful:
+
+- You articulate the problem clearly and provide **steps to reproduce** the problem.
+- **Screenshots or GIFs** are appreciated.
+
+
+## Feature ideas
+
+Ideas are great. All in One SEO Pack needs them. There are so many difficult problems still to solve, and so many opportunities to make the project better. :bulb: :bulb: :bulb:
+
+[Submit a new feature request](https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/new) and start a discussion.
+
+
+## Contributing code
+
+Generally:
+
+1. Open a new issue / pick an existing one
+2. Fork the repo, create a branch, commit to it 
+3. Push the branch, open a pull request
+4. The core team will review it and work with you if necessary
+5. Someone from the core team will merge the PR
+6. :tada:
+
+Smaller changes like updating README's etc. don't need to use the full workflow, a direct PR or sometimes even a commit into `master` is fine. However, most code changes undergo the suggested workflow which is described in more detail [below](#development-workflow).
+
+The following discusses some of the important details if you want to contribute.
+
+### Core values
+
+- **We care about user / dev experience**. Everything that is outward-facing, be it a user interface, developer API or a file format, must be carefully designed for usability and usefulness. We invest our energy to save it for the others.
+- **We care about code quality**. Bad code is a liability, not an asset. We value tests, review each other's code and try to make it good and clean.
+- **We try to be pragmatic**. While we care about quality, the main thing for All in One SEO Pack and its users is to move forward. We're always looking for the right balance.
+
+
+### Our development process
+
+**Major versions** (2.0, 2.1 etc.) are released every few months. Each major version has a [corresponding milestone](https://github.com/semperfiwebdesign/all-in-one-seo-pack/milestones/) and issues are assigned to it by the core team. Issues not assigned to any milestone are in a backlog – we want to do them one day but there's no immediate plans yet.
+
+**Issues** are the most important tool to plan and manage almost everything around VersionPress:
+
+- We create them for new features, bugs, improvements or even larger things like planning documents. **We strongly prefer issues over wiki** or other documents as they are actionable and time-framed.
+- [This set of **labels**](https://github.com/semperfiwebdesign/all-in-one-seo-pack/wiki/Issues#labels) is used to categorize issues.
+- Issues go through **four states**: 'open', 'in progress', 'in review' and 'closed'. There's an [**overv.io board**](https://overv.io/workspace/JanVoracek/cautious-tarsier/) board to visualize that. Also, overv.io helps us set priorities – tickets higher up will be worked on first.
+
+Regarding **branches**, the current release being worked on is **`development`**. It is hence inherently unsafe, even though we do our best to keep it in a good shape. **`Master`** is typically relatively stable.
+
+
+### Development workflow
+
+For small / "safe" changes like updating a README or other Markdown files, quick pull request or even commit into `master` is acceptable. However, for most new code, we use the [GitHub flow](https://guides.github.com/introduction/flow/):
+
+![GitHub Flow](https://guides.github.com/activities/hello-world/branching.png)
+
+Here are the details:
+
+
+1. When you start working on an issue, **move it to the 'in progress' state** (either visually on the [overv.io board](https://overv.io/workspace/JanVoracek/cautious-tarsier/) or by assigning the `in progress` label to the issue) and **create a new feature branch** for it. Name it `<issue number>-<short description>`, e.g., `123-row-filtering`.
+
+    - **Every feature branch should branch off of master**, not another feature branch, even if it depends on it. For dependent feature branches, simply merge between them. This is mainly because when you're going to open a PR for it, you will need to select the target branch (GitHub doesn't let you to change this later) and `master` is the only sensible choice there.
+    
+2. **Commit to this branch**. We appreciate good commits, here are some tips:
+
+    - **Keep commits small and focused**. There are many articles on version control best practices, e.g., [this one](http://www.git-tower.com/learn/git/ebook/command-line/appendix/best-practices) is good. To sum it up, commit small logical changes, prefer smaller commits over large ones and keep project in a workable state at all times.
+    - **Write good commit messages**. We don't have strict rules like [this](http://chris.beams.io/posts/git-commit/), e.g., we don't enforce short subject lines. The main thing for us is that the commit messages are *useful*. Do they make it clear what happened in a commit? Do they reference related commits, if applicable? Good.
+        - We most commonly use past tense ("Added tests") or present tense describing the new situation ("IniSerializer now has tests") but we're not religious about it.
+    - **Link to an issue from the commit message**. Most of the commit messages look like this:
+    
+        ```
+        [#123] Implemented xyz
+        ```
+        
+        It means that the commit belongs to issue `#123`. It makes looking up issues from commits easier.   
+
+
+3. When ready, push the branch, **open a pull request** for it and **move the issue to the 'in review' state** (again, either visually in [overv.io](https://overv.io/workspace/JanVoracek/cautious-tarsier/) or by removing the `in progress` label and adding the `in review` one). You can open a PR early to gather feedback, no worries, you can always add commits to it later. The branch can be push-forced if necessary, it is a "sandbox" to make it great.
+
+    This is an example of a good pull request: [versionpress/versionpress#744](https://github.com/versionpress/versionpress/pull/744). The body usually contains something like:
+    
+        Resolves #123.
+        
+        Some notes on the implementation here if it's not obvious from the code
+        or the list of commits.
+        
+        Reviewers:
+        
+        - [ ] @JanVoracek 
+        - [ ] @borekb 
+    
+    It will be pre-filled for you automatically via GitHub templates, just with a different reviewer (`@versionpress/core-devs` will be there by default, someone from the core team will update it to the actual list of people).
+    
+4. **Core team reviews the PR**. Expect feedback – it is uncommon to receive none – and be open to it. The team will happily work with you to make the code contribution great.
+
+    All checkboxes checked means that the PR is OK to merge.
+    
+    > This is an important nuance because the checkbox can have two meanings: "PR is OK to merge" or "I am done with the review (regardless of whether I still see issues with the code or not)". The former is useful for the one who will eventually perform the merge, the latter is more convenient for a reviewer. We use the first meaning which means that I, as a reviewer, will only check the checkbox after I reported some issues with the code **and they have been fixed**.   
+    
+5. Someone from the core team **merges the pull request**, issue is closed and the branch can be deleted.
+
+A couple of notes:
+
+- As noted above, small / safe changes don't need to undergo this whole process. For example, Markdown files can be **committed directly into `master`** if the changes don't need to be reviewed.
+- We used to use **rebasing** in the past – you can still see that in commits before April 2015 – but left it in favor of merging which is much more natural on GitHub. Plus, rebases [have their own issues](http://geekblog.oneandoneis2.org/index.php/2013/04/30/please-stay-away-from-rebase).
+- **Issues vs. pull requests**: most of the new improvements and features start as issues as they are quick to create and don't require a Git branch. Then there's usually a single PR against the issue (sometimes more but that's relatively rare). However, issues and pull requests are almost the same thing on GitHub and it's not a problem to start something (possibly simpler) directly as a PR.
+
+
+### Style guides
+
+#### PHP style guide
+
+Most of our PHP code follows [**PSR-2**](http://www.php-fig.org/psr/psr-2/), *not* WordPress coding standards. This is deliberate, see [#698](https://github.com/versionpress/versionpress/issues/698). Basically, it's mainly because most of VersionPress is a relatively separate, object oriented system developed recently, where anything but PSR-2 doesn't feel right.
+
+There are a couple of cases where some parts of our code do not adhere to PSR-2 strictly:
+
+- **Code interacting with WordPress** (hooking into it, providing global functions etc.) follows some of WP conventions. For example, global functions are called like `vp_register_hooks()`, not `registerHooks()`.
+- **WP-CLI commands** use filenames similar to the built-in commands, so for instance `VPCommand` lives in a `vp.php` file, not `VPCommand.php`.
+
+Generally, try to follow what's already in place. The project ships with PhpStorm settings, `.editorconfig` etc. so if you use PhpStorm as recommended, it should serve as a good guidance. 
+
+#### JavaScript style guide
+
+The styleguide is under construction. :construction:
+
+
+### Get help
+
+Feel free to reach the devs in the [Gitter room](https://gitter.im/versionpress/versionpress) if you need help with anything.
+
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/versionpress/versionpress)
+
+
+## Improving docs
+
+Documentation contributions coming soon.
+
+
+---
+
+Other ideas of how to contribute? [Tell us](http://semperplugins.com/contact). 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Typically the one-click installer... run bleeding edge coming soon
 
 ## Contributing
 
-1. Create your feature branch: `git checkout -b my-new-feature`
-2. Commit your changes: `git commit -am 'Add some feature'`
-3. Push to the branch: `git push origin my-new-feature`
-4. Submit a pull request :D
+There are many ways to contribute:
+
+- Developers, we'd love [your help](./CONTRIBUTING.md).
+- Suggest a [new feature](https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues).
+- Found a bug? [File an issue](https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues).
+- Beta testers
+
+
 
 ## Supercharge!
 
@@ -23,6 +27,6 @@ Typically the one-click installer... run bleeding edge coming soon
 
 ## Acknowledgements
 
-* Coffee
-* Bacon
-* Coffee
+- [x] Coffee
+- [x] Bacon
+- [ ] More Coffee

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1229,6 +1229,9 @@ if ( !class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		
 		/**
 		 * Load scripts and styles for metaboxes.
+		 * 
+		 * edit-tags exists only for pre 4.5 support... remove when we drop 4.5 support.
+		 * Also, that check and others should be pulled out into their own functions
 		 */
 		function enqueue_metabox_scripts( ) {
 			$screen = '';

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1236,12 +1236,12 @@ if ( !class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 				$screen = get_current_screen();
 			$bail = false;
 			if ( empty( $screen ) ) $bail = true;
-			if ( ( $screen->base != 'post' ) && ( $screen->base != 'term' ) && ( $screen->base != 'toplevel_page_shopp-products' ) ) $bail = true;
+			if ( ( $screen->base != 'post' ) && ( $screen->base != 'term' ) && ( $screen->base != 'edit-tags' ) && ( $screen->base != 'toplevel_page_shopp-products' ) ) $bail = true;
 			$prefix = $this->get_prefix();
 			$bail = apply_filters( $prefix . 'bail_on_enqueue', $bail, $screen );
 			if ( $bail ) return;
 			$this->form = 'post';
-			if ( $screen->base == 'term' ) $this->form = 'edittag';
+			if ( $screen->base == 'term' || $screen->base == 'edit-tags' ) $this->form = 'edittag';
 			if ( $screen->base == 'toplevel_page_shopp-products' ) $this->form = 'product';
 			$this->form = apply_filters( $prefix . 'set_form_on_enqueue', $this->form, $screen );
 			foreach( $this->locations as $k => $v ) {

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1236,12 +1236,12 @@ if ( !class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 				$screen = get_current_screen();
 			$bail = false;
 			if ( empty( $screen ) ) $bail = true;
-			if ( ( $screen->base != 'post' ) && ( $screen->base != 'edit-tags' ) && ( $screen->base != 'toplevel_page_shopp-products' ) ) $bail = true;
+			if ( ( $screen->base != 'post' ) && ( $screen->base != 'term' ) && ( $screen->base != 'toplevel_page_shopp-products' ) ) $bail = true;
 			$prefix = $this->get_prefix();
 			$bail = apply_filters( $prefix . 'bail_on_enqueue', $bail, $screen );
 			if ( $bail ) return;
 			$this->form = 'post';
-			if ( $screen->base == 'edit-tags' ) $this->form = 'edittag';
+			if ( $screen->base == 'term' ) $this->form = 'edittag';
 			if ( $screen->base == 'toplevel_page_shopp-products' ) $this->form = 'product';
 			$this->form = apply_filters( $prefix . 'set_form_on_enqueue', $this->form, $screen );
 			foreach( $this->locations as $k => $v ) {

--- a/admin/meta_import.php
+++ b/admin/meta_import.php
@@ -62,12 +62,12 @@ function aiosp_seometa_action() {
 		return;
 	
 	if ( empty( $_REQUEST['platform_old'] ) ) {
-		printf( '<div class="error"><p>%s</p></div>', __('Sorry, you can\'t do that. Please choose a platform platforms.') );
+		printf( '<div class="error"><p>%s</p></div>', __('Sorry, you can\'t do that. Please choose a platform and then click Analyze or Convert.') );
 		return;
 	}
 		
 	if ( $_REQUEST['platform_old'] == 'All in One SEO Pack' ) {
-		printf( '<div class="error"><p>%s</p></div>', __('Sorry, you can\'t do that. Please choose two different platforms.') );
+		printf( '<div class="error"><p>%s</p></div>', __('Sorry, you can\'t do that. Please choose a platform and then click Analyze or Convert.') );
 		return;
 	}
 		

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -29,11 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * @package All-in-One-SEO-Pack
- * @version 2.3.3.2
+ * @version 2.3.4-alpha
  */
 
 if(!defined('AIOSEOPPRO')) define('AIOSEOPPRO', false);
-if ( ! defined( 'AIOSEOP_VERSION' ) ) define( 'AIOSEOP_VERSION', '2.3.3.2' );
+if ( ! defined( 'AIOSEOP_VERSION' ) ) define( 'AIOSEOP_VERSION', '2.3.4-alpha' );
 global $aioseop_plugin_name;
 $aioseop_plugin_name = 'All in One SEO Pack';
 

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -3,7 +3,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: http://semperfiwebdesign.com
 Description: Out-of-the-box SEO for your WordPress blog. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. Almost 30 million downloads since 2007.
-Version: 2.3.4-alpha
+Version: 2.3.4
 Author: Michael Torbert
 Author URI: http://michaeltorbert.com
 Text Domain: all-in-one-seo-pack
@@ -29,11 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * @package All-in-One-SEO-Pack
- * @version 2.3.4-alpha
+ * @version 2.3.4
  */
 
 if(!defined('AIOSEOPPRO')) define('AIOSEOPPRO', false);
-if ( ! defined( 'AIOSEOP_VERSION' ) ) define( 'AIOSEOP_VERSION', '2.3.4-alpha' );
+if ( ! defined( 'AIOSEOP_VERSION' ) ) define( 'AIOSEOP_VERSION', '2.3.4' );
 global $aioseop_plugin_name;
 $aioseop_plugin_name = 'All in One SEO Pack';
 

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -3,7 +3,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: http://semperfiwebdesign.com
 Description: Out-of-the-box SEO for your WordPress blog. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. Almost 30 million downloads since 2007.
-Version: 2.3.3.2
+Version: 2.3.4-alpha
 Author: Michael Torbert
 Author URI: http://michaeltorbert.com
 Text Domain: all-in-one-seo-pack

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -1116,3 +1116,7 @@ div.sfwd_debug_error {
 	padding-top: 40%;
 }
 */
+.MRL {
+margin-left: 20px !important;
+margin-bottom: 10px !important;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hallsofmontezuma, wpsmort, dougal, pbaylies, arnaudbroes
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mrtorbert%40gmail%2ecom&item_name=All%20In%20One%20SEO%20Pack&item_number=Support%20Open%20Source&no_shipping=0&no_note=1&tax=0&currency_code=USD&lc=US&bn=PP%2dDonationsBF&charset=UTF%2d8
 Tags: seo, SEO, all in one seo, widget, Post, plugin, admin, posts, shortcode, sidebar, google, twitter, page, images, comments, image, social, search engine optimization, sitemap, WordPress SEO, meta, meta description, xml sitemap, xml sitemaps, google sitemap, sitemaps, robots meta, rss, rss footer, yahoo, bing, news sitemaps, XML News Sitemaps, multisite, canonical, nofollow, noindex, keywords, meta keywords, description, webmaster tools, google webmaster tools, google analytics, seo pack
 Requires at least: 3.3
-Tested up to: 4.4
+Tested up to: 4.5
 Stable tag: 2.3.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Resolves: https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/110

Changes to `inc/aioseop_functions.php`: 
Starting from line [790](https://github.com/nabtron/all-in-one-seo-pack/blob/nabtron/inc/aioseop_functions.php#L790) to [952](https://github.com/nabtron/all-in-one-seo-pack/blob/nabtron/inc/aioseop_functions.php#L952)

Shows notice on edit.php listings if the (meta) title or description exceeds the recommended limit with a "click here to view" link, that filters the posts with long title and description

