### PR TITLE
Fixes #687. Adds compatibility class with WPML, global aioseop_home_u…

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -369,6 +369,11 @@ if ( ! function_exists( 'aiosp_action_links' ) ) {
 }
 
 if ( ! function_exists( 'aioseop_init_class' ) ) {
+	/**
+	 * Inits All-in-One-Seo plugin class.
+	 *
+	 * @since 2.3.13 Loads third party compatibility class.
+	 */
 	function aioseop_init_class() {
 		global $aiosp;
 		load_plugin_textdomain( 'all-in-one-seo-pack', false, dirname( plugin_basename( __FILE__ ) ) . '/i18n/' );
@@ -382,6 +387,7 @@ if ( ! function_exists( 'aioseop_init_class' ) ) {
 		require_once( AIOSEOP_PLUGIN_DIR . 'admin/meta_import.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/translations.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/opengraph.php' );
+		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/abstract/aiosep_compatible.php');
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/compat-init.php');
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/front.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/google-analytics.php' );

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -5,6 +5,7 @@
  * We'll eventually move these to a better place, and figure out ones not being used anymore.
  *
  * @package All-in-One-SEO-Pack
+ * @version 2.3.13
  */
 
 if ( ! function_exists( 'aioseop_load_modules' ) ) {
@@ -955,4 +956,20 @@ function aioseop_update_yst_detected_notice() {
 function aioseop_woo_upgrade_notice_dismissed() {
 
 	update_user_meta( get_current_user_id(), 'aioseop_woo_upgrade_notice_dismissed', true );
+}
+
+/**
+ * Returns home_url() value compatible for any use.
+ * Thought for compatibility purposes.
+ *
+ * @since 2.3.13
+ *
+ * @param string $path Relative path to home_url().
+ *
+ * @return string url.
+ */
+function aioseop_home_url( $path = '/' ) {
+
+	$url = apply_filters( 'aioseop_home_url', $path );
+	return $path === $url ? home_url( $path ) : $url;
 }

--- a/inc/compatability/abstract/aiosep_compatible.php
+++ b/inc/compatability/abstract/aiosep_compatible.php
@@ -1,0 +1,31 @@
+<?php
+if ( ! class_exists( 'All_in_One_SEO_Pack_Compatible' ) ) {
+    /**
+     * Abstract class to be used to create compatibility with 3rd party wordpress plugins.
+     *
+     * @package All-in-One-SEO-Pack
+     * @author Alejandro Mostajo
+     * @copyright Semperfi Web Design <https://semperplugins.com/>
+     * @version 2.3.13
+     */
+    abstract class All_in_One_SEO_Pack_Compatible {
+        /**
+         * Returns flag indicating if compatible plugin exists in current instalation or not.
+         * This function should be overwritten on child class.
+         * @since 2.3.13
+         *
+         * @return bool
+         */
+        public function exists() {
+            return false;
+        }
+
+        /**
+         * Method executed by compatibility handler to declare hooks and/or any other compatibility code needed.
+         * @since 2.3.13
+         */
+        public function hooks() {
+            // TODO per compatible plugin.
+        }
+    }
+}

--- a/inc/compatability/compat-init.php
+++ b/inc/compatability/compat-init.php
@@ -5,7 +5,7 @@
  * Eventually we'll have subclasses for each.
  *
  * @package All-in-One-SEO-Pack
- * @since   2.3.6
+ * @since   2.3.13
  */
 
 if ( ! class_exists( 'All_in_One_SEO_Pack_Compatibility' ) ) {
@@ -15,7 +15,17 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Compatibility' ) ) {
 	 *
 	 * @since 2.3.6
 	 */
+
 	class All_in_One_SEO_Pack_Compatibility {
+
+		/**
+		 * List of compatibility classes to execute and run.
+		 *
+		 * @since 2.3.13
+		 *
+		 * @var array
+		 */
+		protected $classes = array();
 
 		/**
 		 * All_in_One_SEO_Pack_Compatibility constructor.
@@ -32,6 +42,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Compatibility' ) ) {
 		 * Load Compatibility Hooks.
 		 *
 		 * @since 2.3.6
+		 * @since 2.3.13 Runs hooks located in compatibility classes.
 		 */
 		public function load_compatibility_hooks() {
 			// We'll use this until we set up our classes.
@@ -47,6 +58,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Compatibility' ) ) {
 			global $aioseop_options;
 			if ( isset( $aioseop_options['modules']['aiosp_feature_manager_options']['aiosp_feature_manager_enable_opengraph'] ) && $aioseop_options['modules']['aiosp_feature_manager_options']['aiosp_feature_manager_enable_opengraph'] === 'on' ) {
 				add_filter( 'twitter_card', array( $this, 'aioseop_disable_twitter' ) );
+			}
+			// Run compatibility classes
+			for ( $i = count( $this->classes ) - 1; $i >= 0; --$i ) {
+				$this->classes[ $i ]->hooks();
 			}
 		}
 
@@ -120,8 +135,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Compatibility' ) ) {
 		 * Load Compatibility classes.
 		 *
 		 * @since 2.3.6
+		 * @since 2.3.13 WPML compatibility loaded.
 		 */
 		public function load_compatibility_classes() {
+			// Load classes
+			require_once __DIR__.'/compat-wpml.php';
+			// Evaluate classes and push them into array
+			$target = new All_in_One_SEO_Pack_Wpml;
+			if ( $target->exists() )
+				$this->classes[] = $target;
 			// Eventually we'll load our other classes from here.
 			$this->load_compatibility_hooks();
 		}

--- a/inc/compatability/compat-wpml.php
+++ b/inc/compatability/compat-wpml.php
@@ -1,0 +1,48 @@
+<?php
+if ( ! class_exists( 'All_in_One_SEO_Pack_Wpml' ) ) {
+    /**
+     * Compatibility with WPML - Wordpress Multilingual Plugin
+     *
+     * @link https://wpml.org/
+     * @package All-in-One-SEO-Pack
+     * @author Alejandro Mostajo
+     * @copyright Semperfi Web Design <https://semperplugins.com/>
+     * @version 2.3.13
+     */
+    class All_in_One_SEO_Pack_Wpml extends All_in_One_SEO_Pack_Compatible {
+        /**
+         * Returns flag indicating if WPML is present.
+         *
+         * @since 2.3.13
+         *
+         * @return bool
+         */
+        public function exists() {
+            return function_exists( 'icl_object_id' );
+        }
+
+        /**
+         * Declares compatibility hooks.
+         *
+         * @since 2.3.13
+         */
+        public function hooks() {
+            add_filter( 'aioseop_home_url', array( &$this, 'aioseop_home_url' ) );
+        }
+
+        /**
+         * Returns specified url filtered by wpml.
+         * This is needed to obtain the correct domain in which wordpress is running on.
+         * AIOSEOP would have ran first expecting the return of home_url().
+         *
+         * @since 2.3.13
+         *
+         * @param string $path Relative path or url.
+         *
+         * @param string filtered url.
+         */
+        public function aioseop_home_url( $path ) {
+            return apply_filters( 'wpml_home_url', home_url( '/' ) ) . preg_replace( '/\//', '', $path, 1);
+        }
+    }
+}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3,6 +3,7 @@
  * Sitemap class.
  *
  * @package All-in-One-SEO-Pack
+ * @version 2.3.13
  */
 
 if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
@@ -603,6 +604,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * Add in options for status display on settings page, sitemap rewriting on multisite.
 		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
+		 *
 		 * @param $options
 		 *
 		 * @return mixed
@@ -614,7 +618,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( isset( $options[ $this->prefix . 'max_posts' ] ) && ( ( $options[ $this->prefix . 'max_posts' ] <= 0 ) || ( $options[ $this->prefix . 'max_posts' ] >= 50000 ) ) ) {
 				$options[ $this->prefix . 'max_posts' ] = 50000;
 			}
-			$url                               = trailingslashit( get_home_url() ) . $options[ $this->prefix . 'filename' ] . '.xml';
+			$url                               = trailingslashit( aioseop_home_url() ) . $options[ $this->prefix . 'filename' ] . '.xml';
 
 			$options[ $this->prefix . 'link' ] = sprintf( __( 'Click here to %s.', 'all-in-one-seo-pack' ), '<a href="' . esc_url( $url ) . '" target="_blank">' . __( 'view your sitemap', 'all-in-one-seo-pack' ) . '</a>' );
 			$options[ $this->prefix . 'link' ] .= __( ' Your sitemap has been created', 'all-in-one-seo-pack' );
@@ -1276,10 +1280,13 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Build a url to the sitemap.
 		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
+		 *
 		 * @return string
 		 */
 		function get_sitemap_url() {
-			$url = get_home_url() . '/' . $this->options["{$this->prefix}filename"] . '.xml';
+			$url = aioseop_home_url( '/' ) . $this->options["{$this->prefix}filename"] . '.xml';
 			if ( $this->options["{$this->prefix}gzipped"] ) {
 				$url .= '.gz';
 			}
@@ -1524,6 +1531,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Build an index of sitemaps used.
 		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
+		 *
 		 * @return array
 		 */
 		function get_sitemap_index_filenames() {
@@ -1542,7 +1552,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 			$options["{$this->prefix}posttypes"]  = array_diff( $options["{$this->prefix}posttypes"], array( 'all' ) );
 			$options["{$this->prefix}taxonomies"] = array_diff( $options["{$this->prefix}taxonomies"], array( 'all' ) );
-			$url_base                             = trailingslashit( get_home_url() );
+			$url_base                             = trailingslashit( aioseop_home_url() );
 			$files[]                              = array( 'loc' => $url_base . $prefix . '_addl' . $suffix );
 			if ( ! empty( $options["{$this->prefix}posttypes"] ) ) {
 				$prio        = $this->get_default_priority( 'post' );
@@ -1789,6 +1799,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Get simple sitemap.
 		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
+		 *
 		 * @return array
 		 */
 		function get_simple_sitemap() {
@@ -1803,7 +1816,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$prio = $this->get_all_post_priority_data( $options["{$this->prefix}posttypes"] );
 
 			$home           = array(
-				'loc'        => get_home_url(),
+				'loc'        => aioseop_home_url(),
 				'priority'   => $this->get_default_priority( 'homepage' ),
 				'changefreq' => $this->get_default_frequency( 'homepage' ),
 			);
@@ -1892,10 +1905,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @see   https://semperplugins.com/documentation/aioseop_sitemap_xsl_url/
 		 *
 		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
 		 */
 		function get_sitemap_xsl() {
 
-			return esc_url( apply_filters( 'aioseop_sitemap_xsl_url', home_url( '/sitemap.xsl' ) ) );
+			return esc_url( apply_filters( 'aioseop_sitemap_xsl_url', aioseop_home_url( '/sitemap.xsl' ) ) );
 		}
 
 		/**
@@ -2213,15 +2227,17 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 		/**
 		 * Gets additional pages.
-		 *
 		 * Return data for user entered additional pages.
+		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
 		 *
 		 * @return array|mixed|void
 		 */
 		function get_addl_pages_only() {
 			$pages = array();
 			if ( ! empty( $this->options[ $this->prefix . 'addl_pages' ] ) ) {
-				$siteurl = parse_url( get_home_url() );
+				$siteurl = parse_url( aioseop_home_url() );
 				foreach ( $this->options[ $this->prefix . 'addl_pages' ] as $k => $v ) {
 					$url = parse_url( $k );
 					if ( empty( $url['scheme'] ) ) {
@@ -2266,12 +2282,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Return data for user entered additional pages and extra pages.
 		 *
+		 * @since 2.3.6
+		 * @since 2.3.13 Refactored to use aioseop_home_url() for compatibility purposes.
+		 *
 		 * @return array|mixed|void
 		 */
 		function get_addl_pages() {
 			$home  = array();
 			$home  = array(
-				'loc'        => get_home_url(),
+				'loc'        => aioseop_home_url(),
 				'priority'   => $this->get_default_priority( 'homepage' ),
 				'changefreq' => $this->get_default_frequency( 'homepage' ),
 			);


### PR DESCRIPTION
…rl() and refactores sitemap generator.

Solves compatibility issue with WPML by refactoring the usage of
"home_url" and "get_home_url" when generating sitemaps. Additionally it
extends the solution of compatibility with third party support by adding
an abtract class and integration with the plugin. Global function to
handle variations of "home_url" has been added as "aioseop_home_url".