### PR TITLE
Bad Bot Blocker - Strip blank line at beginning of blocklist #680

### DIFF
--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -502,11 +502,13 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			$regex = '';
 			$cont  = 0;
 			foreach ( $list as $l ) {
-				if ( $cont && ! empty( $l ) ) {
-					$regex .= '|';
+				if ( ! empty( $l ) ) {
+					if ( $cont ) {
+						$regex .= '|';
+					}
+					$cont = 1;
+					$regex .= preg_quote( trim( $l ), $quote );
 				}
-				$cont = 1;
-				$regex .= preg_quote( trim( $l ), $quote );
 			}
 
 			return $regex;


### PR DESCRIPTION
The function 'quote_list_for_regex' in the 'module_class' file filters out blank lines from the beginning, middle and end, but only one blank line in the beginning. So I successfully replicated an issue when added a few blank lines in the beginning. Now it filters out all blank lines.