### PR TITLE
Issue #899 - Fixes non-breaking-space entity appearing in description.

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4818,7 +4818,7 @@ EOF;
 
 	/**
 	 * Filters meta value and applies generic cleanup.
-	 * - Removal of HTML entities (ie: &nbsp;).
+	 * - Removal of some HTML entities (ie: &nbsp;).
 	 * - Removal of urls.
 	 * - Internal trim.
 	 * Returns cleaned value.
@@ -4832,8 +4832,8 @@ EOF;
 	public function filter_meta_value( $value, $is_url = false ) {
 		$value = preg_replace(
 			array(
-				'/\&[\s\S]+\;/',// Remove HTML entities
-				$is_url ? '/\&[\s\S]+\;/' : '@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
+				'/\&(nbsp)\;/',// Remove HTML entities
+				$is_url ? '/\&n\/a\;/' : '@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
 			),
 			array(
 				'', // Replacement HTML entities

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3620,7 +3620,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			add_action( 'amp_post_template_head', array( $this, 'amp_head' ), 11 );
 			add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );
 		}
-		add_filter( 'aioseop_meta_value', array( &$this, 'filter_meta_value' ), 1 );
+		add_filter( 'aioseop_meta_value', array( &$this, 'filter_meta_value' ), 10, 2 );
 	}
 
 	function visibility_warning() {
@@ -4819,6 +4819,7 @@ EOF;
 	/**
 	 * Filters meta value and applies generic cleanup.
 	 * - Removal of HTML entities (ie: &nbsp;).
+	 * - Removal of urls.
 	 * - Internal trim.
 	 * Returns cleaned value.
 	 *
@@ -4828,9 +4829,18 @@ EOF;
 	 *
 	 * @return string
 	 */
-	public function filter_meta_value( $value ) {
-		// Remove HTML entities
-		$value = preg_replace( '/\&[\s\S]+\;/', '', $value );
+	public function filter_meta_value( $value, $is_url = false ) {
+		$value = preg_replace(
+			array(
+				'/\&[\s\S]+\;/',// Remove HTML entities
+				$is_url ? '/\&[\s\S]+\;/' : '@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
+			),
+			array(
+				'', // Replacement HTML entities
+				'', // Replacement URLs
+			),
+			$value
+		);
 		// Internal whitespace trim.
 		$value = preg_replace( '/\s\s+/u', ' ', $value );
 		return $value;

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2538,7 +2538,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * Gets post description.
 	 * Auto-generates description if settings are ON.
 	 *
-	 * @since 2.3.13 #899 Fixes non breacking space, applies filter "aioseop_meta_value".
+	 * @since 2.3.13 #899 Fixes non breacking space, applies filter "aioseop_description".
 	 *
 	 * @param object $post Post object.
 	 *
@@ -2568,7 +2568,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 		}
 
-		return apply_filters( 'aioseop_meta_value', $description );
+		return apply_filters( 'aioseop_description', $description );
 	}
 
 	/**
@@ -3577,7 +3577,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	/**
 	 * Adds wordpress hooks.
 	 *
-	 * @since 2.3.13 #899 Adds filter:filter_meta_value.
+	 * @since 2.3.13 #899 Adds filter:aioseop_description.
 	 */
 	function add_hooks() {
 		global $aioseop_options, $aioseop_update_checker;
@@ -3620,7 +3620,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			add_action( 'amp_post_template_head', array( $this, 'amp_head' ), 11 );
 			add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );
 		}
-		add_filter( 'aioseop_meta_value', array( &$this, 'filter_meta_value' ), 10, 2 );
+		add_filter( 'aioseop_description', array( &$this, 'filter_description' ) );
 	}
 
 	function visibility_warning() {
@@ -4818,25 +4818,25 @@ EOF;
 
 	/**
 	 * Filters meta value and applies generic cleanup.
-	 * - Removal of some HTML entities (ie: &nbsp;).
+	 * - Decode HTML entities.
 	 * - Removal of urls.
 	 * - Internal trim.
 	 * Returns cleaned value.
 	 *
 	 * @since 2.3.13
 	 *
-	 * @param mixed $value Value to filter.
+	 * @param string $value Value to filter.
 	 *
 	 * @return string
 	 */
-	public function filter_meta_value( $value, $is_url = false ) {
+	public function filter_description( $value) {
+		// Decode entities
+		$value = html_entity_decode( $value );
 		$value = preg_replace(
 			array(
-				'/\&(nbsp)\;/',// Remove HTML entities
-				$is_url ? '/\&n\/a\;/' : '@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
+				'@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
 			),
 			array(
-				'', // Replacement HTML entities
 				'', // Replacement URLs
 			),
 			$value

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2535,7 +2535,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	}
 
 	/**
-	 * @param $post
+	 * Gets post description.
+	 * Auto-generates description if settings are ON.
+	 *
+	 * @since 2.3.13 #899 Fixes non breacking space, applies filter "aioseop_meta_value".
+	 *
+	 * @param object $post Post object.
 	 *
 	 * @return mixed|string
 	 */
@@ -2563,10 +2568,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 		}
 
-		// Internal whitespace trim.
-		$description = preg_replace( '/\s\s+/u', ' ', $description );
-
-		return $description;
+		return apply_filters( 'aioseop_meta_value', $description );
 	}
 
 	/**
@@ -3572,6 +3574,11 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		return preg_replace( '/<title([^>]*?)\s*>([^<]*?)<\/title\s*>/is', '<title\\1>' . preg_replace( '/(\$|\\\\)(?=\d)/', '\\\\\1', strip_tags( $title ) ) . '</title>', $content, 1 );
 	}
 
+	/**
+	 * Adds wordpress hooks.
+	 *
+	 * @since 2.3.13 #899 Adds filter:filter_meta_value.
+	 */
 	function add_hooks() {
 		global $aioseop_options, $aioseop_update_checker;
 
@@ -3613,6 +3620,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			add_action( 'amp_post_template_head', array( $this, 'amp_head' ), 11 );
 			add_action( 'template_redirect', array( $this, 'template_redirect' ), 0 );
 		}
+		add_filter( 'aioseop_meta_value', array( &$this, 'filter_meta_value' ), 1 );
 	}
 
 	function visibility_warning() {
@@ -4806,6 +4814,26 @@ EOF;
 	}
 
 	function display_settings_footer() {
+	}
+
+	/**
+	 * Filters meta value and applies generic cleanup.
+	 * - Removal of HTML entities (ie: &nbsp;).
+	 * - Internal trim.
+	 * Returns cleaned value.
+	 *
+	 * @since 2.3.13
+	 *
+	 * @param mixed $value Value to filter.
+	 *
+	 * @return string
+	 */
+	public function filter_meta_value( $value ) {
+		// Remove HTML entities
+		$value = preg_replace( '/\&[\s\S]+\;/', '', $value );
+		// Internal whitespace trim.
+		$value = preg_replace( '/\s\s+/u', ' ', $value );
+		return $value;
 	}
 
 	function display_right_sidebar() {

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -760,7 +760,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 					$info = $aiosp->get_page_snippet_info();
 					extract( $info );
 					// Add filters
-					$description = apply_filters( 'aioseop_meta_value', $description );
+					$description = apply_filters( 'aioseop_description', $description );
 					// Add placholders
 					$settings["{$prefix}title"]['placeholder'] = $title;
 					$settings["{$prefix}desc"]['placeholder']  = $description;
@@ -882,7 +882,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 		 *
 		 * @since 1.0.0
 		 * @since 2.3.11.5 Support for multiple fb_admins.
-		 * @since 2.3.13   Adds filter:aioseop_meta_value on description.
+		 * @since 2.3.13   Adds filter:aioseop_description on description.
 		 */
 		function add_meta() {
 			global $post, $aiosp, $aioseop_options, $wp_query;
@@ -1203,7 +1203,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			}
 
 			// Apply last filters.
-			$description = apply_filters( 'aioseop_meta_value', $description );
+			$description = apply_filters( 'aioseop_description', $description );
 
 			$meta = Array(
 				'facebook' => Array(
@@ -1265,12 +1265,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 						 * This is to accomodate multiple fb:admins on separate lines.
 						 * @TODO Eventually we'll want to put this in its own function so things like images work too.
 						 */
-						if( 'key' === $k ){
+						if ( 'key' === $k ){
 							$fbadmins = explode( ',', str_replace(' ', '', $filtered_value[0] ) ); // Trim spaces then turn comma-separated values into an array.
 							foreach( $fbadmins as $fbadmin){
 								echo '<meta ' . $tags[ $t ]['name'] . '="' . $v . '" ' . $tags[ $t ]['value'] . '="' . $fbadmin . '" />' . "\n";
 							}
-						}else{
+						} else {
 							// For everything else.
 							foreach ( $filtered_value as $f ) {
 								echo '<meta ' . $tags[ $t ]['name'] . '="' . $v . '" ' . $tags[ $t ]['value'] . '="' . $f . '" />' . "\n";

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -759,6 +759,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 					global $aiosp;
 					$info = $aiosp->get_page_snippet_info();
 					extract( $info );
+					// Add filters
+					$description = apply_filters( 'aioseop_meta_value', $description );
+					// Add placholders
 					$settings["{$prefix}title"]['placeholder'] = $title;
 					$settings["{$prefix}desc"]['placeholder']  = $description;
 				}
@@ -879,6 +882,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 		 *
 		 * @since 1.0.0
 		 * @since 2.3.11.5 Support for multiple fb_admins.
+		 * @since 2.3.13   Adds filter:aioseop_meta_value on description.
 		 */
 		function add_meta() {
 			global $post, $aiosp, $aioseop_options, $wp_query;
@@ -1197,6 +1201,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 				// Set Twitter image from custom.
 				$twitter_thumbnail = set_url_scheme( $metabox['aioseop_opengraph_settings_customimg_twitter'] );
 			}
+
+			// Apply last filters.
+			$description = apply_filters( 'aioseop_meta_value', $description );
 
 			$meta = Array(
 				'facebook' => Array(


### PR DESCRIPTION
Fixes non-breaking-space entity appearing in auto-generated description.
Adds new generic filter that cleans up meta values, can be applied to
other descriptions in the future.