### PR TITLE
#916 Strips links except anchor texts on descriptions.

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4839,22 +4839,26 @@ EOF;
 	 * - Internal trim.
 	 * - External trim.
 	 * - Strips HTML.
+	 * - Strips HTML except anchor texts.
 	 * Returns cleaned value.
 	 *
 	 * @since 2.3.13
+	 * @since 2.3.14 Strips except anchor texts.
 	 *
 	 * @param string $value Value to filter.
 	 *
 	 * @return string
 	 */
-	public function filter_description( $value) {
+	public function filter_description( $value ) {
 		// Decode entities
 		$value = html_entity_decode( $value );
 		$value = preg_replace(
 			array(
+				'#<a.*?>([^>]*)</a>#i', // Remove link but keep anchor text
 				'@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s])?)?)@',// Remove URLs
 			),
 			array(
+				'$1', // Replacement link's anchor text.
 				'', // Replacement URLs
 			),
 			$value


### PR DESCRIPTION
This is for issue #916 

Added rule to `aioseop_description` so HTML links are stripped by their
anchor text is kept.