### PR TITLE
#1062 Fix for text being cut off

### DIFF
--- a/css/modules/aioseop_module-rtl.css
+++ b/css/modules/aioseop_module-rtl.css
@@ -46,6 +46,7 @@
 }
 
 .aioseop input[type="text"] {
+    height: 35px;
     padding: 2px 10px 2px 0
 }
 

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -163,7 +163,6 @@ div.aioseop_tip_icon:before {
 
 .aioseop input[type="text"] {
     color: #515151;
-    height: 35px;
     padding: 10px 0 10px 10px;
     font-size: 14px;
     width: 95%;


### PR DESCRIPTION
Issue #1062 
This fixes an issue with Firefox where the bottom of text in text input fields was being cut off.