### PR TITLE
#1074 Turns on image checker on custom url change

### DIFF
--- a/js/modules/aioseop_module.js
+++ b/js/modules/aioseop_module.js
@@ -242,6 +242,17 @@ jQuery( document ).ready(function() {
 			aioseop_do_condshow( aiosp_data.condshow );
 		}
 	}
+
+	/**
+     * Turns on image checker on custom url change.
+     * @since 2.3.16
+     */
+	jQuery( '.aioseop_upload_image_label' ).on( 'change', function() {
+		this.checker = jQuery( this ).parent().find( '.aioseop_upload_image_checker' );
+		if ( this.checker.length > 0 ) {
+			this.checker.val( 1 );
+		}
+	} );
 });
 
 /**


### PR DESCRIPTION
Issue #1074 
Turns ON image checker on custom image value change (most likely due to
custom url being pasted). Compatible with image uploader.