### PR TITLE
#1187  no the_content filter when looking for sitemap images

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -2690,7 +2690,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			// Check images in the content.
-			$content = apply_filters( 'the_content', $post->post_content );
+			$content = $post->post_content;
 			$total   = substr_count( $content, '<img ' ) + substr_count( $content, '<IMG ' );
 			if ( $total > 0 ) {
 				$dom = new domDocument();


### PR DESCRIPTION
remove the_content filter when looking for sitemap images

It would be nice to know whether this was intentional, and a) if there's a better way to accomplish what we want to accomplish and b) if we're better off without applying the filter than with.