### PR TITLE
Fix PHP Error with file_get_contents() & Sitemap not generating #1428 

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1027,9 +1027,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						}
 					} else {
 						if ( $compressed ) {
-							$fn = 'compress.zlib://' . $fn;
+							$file_resource = gzopen( $fn, 'rb' );
+							$file = gzread( $file_resource, 4096 );
+							gzclose( $file_resource );
+						} else {
+							$file = file_get_contents( $fn, false, null, 0, 4096 );
 						}
-						$file = file_get_contents( $fn, false, null, - 1, 4096 );
 					}
 					if ( ! empty( $file ) ) {
 						$matches = array();
@@ -1048,6 +1051,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						$msg .= '<p>' . sprintf( __( 'Removed empty file %s.', 'all-in-one-seo-pack' ), $f ) . "</p>\n";
 						$problem_files[] = $f;
 
+						// This is causing all problem_files to be deleted automatically; which may be the intent.
+						// TODO Either create a seperate variable for this set of problem_files, or a final loop to clean problem_files before returning.
 						foreach ( $problem_files as $f => $file ) {
 							$files[ $f ] = realpath( $file );
 							$this->delete_file( realpath( $file ) );


### PR DESCRIPTION
* Issue #1428 - Fix PHP Error and sitemap not generating.
    * Fix Static Compressed Sitemap being deleted automatically because of a false-false return.
        * Fix AIOSEOP Error message "Removed empty file *"
        * NOTE: This is caused by a 7.1.0 change that is intended to prevent remote access for hackers.
        * ToDo/NOTE: Problem_Files within the array were all being deleted because of a false potential problem.
    * Fix PHP 7.1.0 - 7.2.0+ (current) Warning with Compressed Streams to file path.
* Fix Static Sitemap undetected to delete when Dynamic Sitemap is enabled.
    * NOTE: file_get_contents was grabbing the end of the file.
* Fix Error message "Potential conflict with unknown file *" with a valid .xml file.

