### PR TITLE
Fix Sitemap Notice from showing to non-admins #1345

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -332,6 +332,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$sitemap_max_url_notice_dismissed = get_user_meta( get_current_user_id(), 'aioseop_sitemap_max_url_notice_dismissed', true );
 			if ( ! empty( $sitemap_max_url_notice_dismissed ) ) {
 				return;
+			} elseif ( ! current_user_can( 'aiosp_manage_seo' ) ) {
+				return;
 			}
 
 			$options = $this->options;


### PR DESCRIPTION
Fix Sitemap Notice from showing to non-admins #1345 PR #1540
This uses the `aiosp_manage_seo` capability.