### PR TITLE
Use `rewrite_rules_array` as a filter

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1136,7 +1136,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * Set up hooks for rewrite rules for dynamic sitemap generation.
 		 */
 		function setup_rewrites() {
-			add_action( 'rewrite_rules_array', array( $this, 'rewrite_hook' ) );
+			add_filter( 'rewrite_rules_array', array( $this, 'rewrite_hook' ) );
 			add_filter( 'query_vars', array( $this, 'query_var_hook' ) );
 			add_action( 'parse_query', array( $this, 'sitemap_output_hook' ) );
 			if ( ! get_transient( "{$this->prefix}rules_flushed" ) ) {


### PR DESCRIPTION
Hi! I noticed this when reviewing the plugin functionality.

`rewrite_rules_array` is a filter, not an action and even though this works currently it is technically incorrect and might break in the future: https://developer.wordpress.org/reference/hooks/rewrite_rules_array/