### PR TITLE
Fixed option filtering

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -4,7 +4,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for your WordPress blog. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 30 million downloads since 2007.
-Version: 2.7.2
+Version: 2.7.3
 Author: Michael Torbert
 Author URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Text Domain: all-in-one-seo-pack
@@ -32,14 +32,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The original WordPress SEO plugin.
  *
  * @package All-in-One-SEO-Pack
- * @version 2.7.2
+ * @version 2.7.3
  */
 
 if ( ! defined( 'AIOSEOPPRO' ) ) {
 	define( 'AIOSEOPPRO', false );
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '2.7.2' );
+	define( 'AIOSEOP_VERSION', '2.7.3' );
 }
 global $aioseop_plugin_name;
 $aioseop_plugin_name = 'All in One SEO Pack';

--- a/inc/compatability/compat-wpml.php
+++ b/inc/compatability/compat-wpml.php
@@ -29,6 +29,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Wpml' ) ) {
 		public function hooks() {
 			add_filter( 'aioseop_home_url', array( &$this, 'aioseop_home_url' ) );
 			add_filter( 'aioseop_sitemap_xsl_url', array( &$this, 'aioseop_sitemap_xsl_url' ) );
+			add_action( 'init', 'aioseop_get_options' );
 		}
 
 		/**

--- a/inc/compatability/compat-wpml.php
+++ b/inc/compatability/compat-wpml.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Wpml' ) ) {
 		public function hooks() {
 			add_filter( 'aioseop_home_url', array( &$this, 'aioseop_home_url' ) );
 			add_filter( 'aioseop_sitemap_xsl_url', array( &$this, 'aioseop_sitemap_xsl_url' ) );
-			add_action( 'init', 'aioseop_get_options' );
+			add_action( 'init', 'aioseop_get_options' ); // #1761 Options are called too early to work with WPML.
 		}
 
 		/**

--- a/inc/compatability/compat-wpml.php
+++ b/inc/compatability/compat-wpml.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Wpml' ) ) {
 		public function hooks() {
 			add_filter( 'aioseop_home_url', array( &$this, 'aioseop_home_url' ) );
 			add_filter( 'aioseop_sitemap_xsl_url', array( &$this, 'aioseop_sitemap_xsl_url' ) );
-			add_action( 'init', 'aioseop_get_options' ); // #1761 Options are called too early to work with WPML.
+			add_action( 'init', 'aioseop_get_options' ); // #1761 Options are otherwise called too early to work with WPML.
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mrtor
 Tags: SEO, all in one seo, WordPress SEO, Google Search Console, XML Sitemap, image seo
 Requires at least: 4.4
 Tested up to: 4.9
-Stable tag: 2.7.1
+Stable tag: 2.7.3
 License: GPLv2 or later
 Requires PHP: 5.2.4
 


### PR DESCRIPTION
WPML stopped filtering AIOSEOP options.
get_options() is called too early (soon as plugin is loaded) and translations are not applied.
Fixed by triggering another call on 'init' hook.