### PR TITLE
Fix shortcodes affecting Auto Descriptions

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2625,6 +2625,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function trim_text_without_filters_full_length( $text ) {
 		$text = str_replace( ']]>', ']]&gt;', $text );
+		$text = strip_shortcodes( $text );
 		$text = wp_strip_all_tags( $text );
 
 		return trim( $text );
@@ -2640,6 +2641,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function trim_excerpt_without_filters( $text, $max = 0 ) {
 		$text = str_replace( ']]>', ']]&gt;', $text );
+		$text = strip_shortcodes( $text );
 		$text = wp_strip_all_tags( $text );
 		// Treat other common word-break characters like a space.
 		$text2 = preg_replace( '/[,._\-=+&!\?;:*]/s', ' ', $text );


### PR DESCRIPTION
Issue #1995

## Proposed changes
This semi-restores changes that occurred in #1964. This uses WP function for stripping shortcodes; [strip_shortcodes()](https://developer.wordpress.org/reference/functions/strip_shortcodes/).

### Commit Desc
Strips valid shortcodes and preserves non shortcodes. Includes removing end-shortcodes ( `[/shortcode]` )

This can still allow shortcodes that aren't registered/enabled (plugin isn't active)

