### PR TITLE
Change/Remove method get_facebook_debug() to enqueue JS instead

### DIFF
--- a/js/modules/aioseop_opengraph.js
+++ b/js/modules/aioseop_opengraph.js
@@ -1,0 +1,21 @@
+/**
+ * Script for AIOSEOP OpenGraph
+ *
+ * @summary For AIOSEOP OpenGraph settings on AIOSEOP screens & edit post screen (possibly more others).
+ *
+ * @author Michael Torbert.
+ * @author Semper Fi Web Design.
+ * @copyright https://semperplugins.com
+ * @version 2.9.2
+ */
+
+jQuery(document).ready(function () {
+	var snippet = jQuery("#aioseop_snippet_link");
+	if (snippet.length === 0) {
+		jQuery("#aioseop_opengraph_settings_facebook_debug_wrapper").hide();
+	} else {
+		snippet = snippet.html();
+		jQuery("#aioseop_opengraph_settings_facebook_debug")
+			.attr("href", "https://developers.facebook.com/tools/debug/sharing/?q=" + snippet);
+	}
+});

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -454,7 +454,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 					'name'    => __( 'Facebook Debug', 'all-in-one-seo-pack' ),
 					'type'    => 'html',
 					'save'    => false,
-					'default' => $this->get_facebook_debug(),
+					'default' => '<a 
+						name="aioseop_opengraph_settings_facebook_debug"
+						id="aioseop_opengraph_settings_facebook_debug"
+						class="button-primary"
+						href=""
+						target="_blank">' . __( 'Debug This Post', 'all-in-one-seo-pack' ) . '</a>',
 				),
 				'section'                => array(
 					'name'     => __( 'Article Section', 'all-in-one-seo-pack' ),
@@ -1642,6 +1647,34 @@ END;
 		}
 
 		/**
+		 * Admin Enqueue Scripts
+		 *
+		 * Add hook in \All_in_One_SEO_Pack_Module::enqueue_metabox_scripts - Bails adding hook if not on target valid screen.
+		 * Add hook in \All_in_One_SEO_Pack_Module::add_page_hooks - Function itself is hooked based on the screen_id/page.
+		 *
+		 * @since 2.9.2
+		 *
+		 * @see 'admin_enqueue_scripts' hook
+		 * @link https://developer.wordpress.org/reference/hooks/admin_enqueue_scripts/
+		 *
+		 * @param string $hook_suffix
+		 */
+		public function admin_enqueue_scripts( $hook_suffix ) {
+			wp_enqueue_script(
+				'aioseop-opengraph-script',
+				AIOSEOP_PLUGIN_URL . 'js/modules/aioseop_opengraph.js',
+				array(),
+				AIOSEOP_VERSION
+			);
+
+			// Dev note: If certain JS files need to be restricted to select screens, then follow concept
+			// used in `All_in_One_SEO_Pack::admin_enqueue_scripts()` (v2.9.1); which uses the `$hook_suffix`
+			// and a switch-case. This also helps prevent unnessecarily processing localized data when it isn't needed.
+
+			parent::admin_enqueue_scripts( $hook_suffix );
+		}
+
+		/**
 		 * Enqueue our file upload scripts and styles.
 		 * @param $hook
 		 */
@@ -1717,37 +1750,6 @@ END;
 				$options[ $prefix . 'customimg_checker' ] = 0;
 			}
 			return $options;
-		}
-
-		/**
-		 * Returns facebook debug script and link.
-		 * @since 2.4.14
-		 *
-		 * @return string
-		 */
-		private function get_facebook_debug() {
-			ob_start();
-			?>
-            <script>
-                jQuery(document).ready(function () {
-                    var snippet = jQuery("#aioseop_snippet_link");
-                    if (snippet.length === 0) {
-                        jQuery("#aioseop_opengraph_settings_facebook_debug_wrapper").hide();
-                    } else {
-                        snippet = snippet.html();
-                        jQuery("#aioseop_opengraph_settings_facebook_debug")
-                            .attr("href", "https://developers.facebook.com/tools/debug/sharing/?q=" + snippet);
-                    }
-                });
-            </script>
-            <a name="aioseop_opengraph_settings_facebook_debug"
-               id="aioseop_opengraph_settings_facebook_debug"
-               class="button-primary"
-               href=""
-               target="_blank"
-            ><?php echo __( 'Debug This Post', 'all-in-one-seo-pack' ); ?></a>
-			<?php
-			return ob_get_clean();
 		}
 	}
 }


### PR DESCRIPTION
Issue #2037

## Proposed changes

Previously located in `All_in_One_SEO_Pack_Opengraph::get_facebook_debug()`. The JS code was changed be in a JS File instead, and remaining code was moved to where it was being called; since the only justification was with JS.

For testing: This seemed to only related to the admin Post Edit screen > AIOSEOP Social Settings > Facebook Debug.

