### PR TITLE
Properly escape image upload variables

### DIFF
--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -2328,10 +2328,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 							"<input class='aioseop_upload_image_button button-primary' type='button' value='";
 					$buf .= __( 'Upload Image', 'all-in-one-seo-pack' );
 					$buf .= "' style='float:left;' />" .
-							"<input class='aioseop_upload_image_label' name='$name' type='text' $attr value='$value' size=57 style='float:left;clear:left;'>\n";
+							"<input class='aioseop_upload_image_label' name='" . esc_attr( $name ) . "' type='text' " . esc_html( $attr ) . " value='" . esc_attr( $value ) . "' size=57 style='float:left;clear:left;'>\n";
 					break;
 				case 'html':
-					$buf .= $value;
+					$buf .= wp_kses( $value, wp_kses_allowed_html( 'post' ) );
 					break;
 				case 'esc_html':
 					$buf .= '<pre>' . esc_html( $value ) . "</pre>\n";
@@ -2341,7 +2341,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 					wp_enqueue_script( 'jquery-ui-datepicker' );
 					// fall through.
 				default:
-					$buf .= "<input name='$name' type='{$options['type']}' $attr value='$value'>\n";
+					$buf .= "<input name='" . esc_attr( $name ) . "' type='" . esc_attr( $options['type'] ) . "' " . wp_kses( $attr, wp_kses_allowed_html( 'data' ) ) . " value='" . esc_attr( $value ) . "'>\n";
 			}
 			if ( ! empty( $options['count'] ) ) {
 				$size = 60;


### PR DESCRIPTION
Related to https://github.com/semperfiwebdesign/aioseop-pro/issues/450

The text `'><script>alert(1)</script>'` in this case is the expected bug being created in Custom Twitter Image with the test hook/function. The script is prevented from executing, but renders as text instead; as far as I know, that is expected, and the source of the problem should be identified and removed. I don't think it can be exploited any further though.

![i-450-social-settings](https://user-images.githubusercontent.com/2794445/48085735-f7ef9480-e1af-11e8-9cd5-9c712e5f3a3e.png)
