### PR TITLE
Add sitemap optimization

### DIFF
--- a/inc/aiosp_common.php
+++ b/inc/aiosp_common.php
@@ -15,6 +15,13 @@ class aiosp_common {
 // @codingStandardsIgnoreEnd
 
 	/**
+	 * @var null|array
+	 *
+	 * @since 2.9.2
+	 */
+	public static $attachment_url_postids = null;
+
+	/**
 	 * aiosp_common constructor.
 	 *
 	 */
@@ -182,4 +189,255 @@ class aiosp_common {
 		return $value;
 	}
 
+	/**
+	 * Attachment URL to Post ID
+	 *
+	 * Returns the (original) post/attachment ID from the URL param given. The function checks if URL is
+	 * within, chacks for original attachment URLs, and then custom attachment URLs. The main intent for this function
+	 * is to avoid having to query if possible (if cache was set prior), and if not, there is only 1 query per instance
+	 * rather than multiple queries per instance.
+	 * NOTE: Attempting to paginate the query actually caused the memory to peak higher.
+	 * NOTE: The weakest point in this function is multiple calls to Result_2's SQL query for custom attachment URLs.
+	 *
+	 * This is intended to work much the same way as WP's `attachment_url_to_postid()`.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/attachment_url_to_postid/
+	 *
+	 * @see aiosp_common::set_transient_url_postids()
+	 * @see get_transient()
+	 * @link https://developer.wordpress.org/reference/functions/get_transient/
+	 * @see wpdb::get_results()
+	 * @link https://developer.wordpress.org/reference/classes/wpdb/get_results/
+	 * @see wp_list_pluck()
+	 * @link https://developer.wordpress.org/reference/functions/wp_list_pluck/
+	 * @see wp_upload_dir()
+	 * @link https://developer.wordpress.org/reference/functions/wp_upload_dir/
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param string $url Full image URL.
+	 * @return int
+	 */
+	public static function attachment_url_to_postid( $url ) {
+		global $wpdb;
+		static $results_1;
+		static $results_2;
+
+		$id = 0;
+		$url_md5 = md5( $url );
+
+		// Gets the URL => PostIDs array.
+		// If static variable is still empty, load transient data.
+		if ( is_null( self::$attachment_url_postids ) ) {
+			if ( is_multisite() ) {
+				self::$attachment_url_postids = get_site_transient( 'multisite_aioseop_attachment_url_postids' );
+			} else {
+				self::$attachment_url_postids = get_transient( 'aioseop_attachment_url_postids' );
+			}
+
+			// If no transient data, set as (default) empty array.
+			if ( false === self::$attachment_url_postids ) {
+				self::$attachment_url_postids = array();
+			}
+		}
+
+		// Search for URL and get ID.
+		if ( isset( self::$attachment_url_postids[ $url_md5 ] ) ) {
+			// If static is already loaded and has URL, then return the URL's Post ID.
+			$id = intval( self::$attachment_url_postids[ $url_md5 ] );
+		} else {
+			// Check to make sure Image URL is not outside the website.
+			$uploads_dir = wp_upload_dir();
+			if ( false !== strpos( $url, $uploads_dir['baseurl'] . '/' ) ) {
+				// Results_1 query looks for URLs with the original guid that is uncropped and unedited.
+				if ( is_null( $results_1 ) ) {
+					$results_1 = aiosp_common::attachment_url_to_postid_query_1();
+				}
+
+				if ( isset( $results_1[ $url_md5 ] ) ) {
+					$id = intval( $results_1[ $url_md5 ] );
+				}
+
+				// TODO Add setting to enable; this is TOO MEMORY INTENSE which could result in 1 or more crashes,
+				// TODO however some may still need custom image URLs.
+				// TODO NOTE: Transient data does prevent continual crashes.
+//				else {
+//					// Results_2 query looks for the URL that is cropped and edited. This searches JSON strings
+//					// and returns the original attachment ID (there is no custom attachment IDs).
+//
+//					if ( is_null( $results_2 ) ) {
+//						$results_2 = aiosp_common::attachment_url_to_postid_query_2();
+//					}
+//
+//					if ( isset( $results_2[ $url_md5 ] ) ) {
+//						$id = intval( $results_2[ $url_md5 ] );
+//					}
+//				}
+			}
+
+			self::$attachment_url_postids[ $url_md5 ] = $id;
+
+			/**
+			 * Sets the transient data at the last hook instead at every call.
+			 *
+			 * @see aiosp_common::set_transient_url_postids()
+			 */
+			add_action( 'shutdown', 'aiosp_common::set_transient_url_postids' );
+		}
+
+		return $id;
+	}
+
+	/**
+	 * Sets the transient data at the last hook instead at every call.
+	 *
+	 * @see set_transient()
+	 * @link https://developer.wordpress.org/reference/functions/set_transient/
+	 *
+	 * @since 2.9.2
+	 */
+	public static function set_transient_url_postids() {
+		if ( is_multisite() ) {
+			set_site_transient( 'multisite_aioseop_attachment_url_postids', self::$attachment_url_postids, 24 * HOUR_IN_SECONDS );
+		} else {
+			set_transient( 'aioseop_attachment_url_postids', self::$attachment_url_postids, 24 * HOUR_IN_SECONDS );
+		}
+
+	}
+
+	/**
+	 * Attachment URL to Post ID - Query 1
+	 *
+	 * This is intended to work solely with `aiosp_common::attachment_url_to_post_id()`. Calling this multiple times
+	 * is memory intense.
+	 *
+	 * @see wpdb::get_results()
+	 * @link https://developer.wordpress.org/reference/classes/wpdb/get_results/
+	 *
+	 * @return array
+	 */
+	public static function attachment_url_to_postid_query_1() {
+		global $wpdb;
+
+		$results_1 = $wpdb->get_results(
+			"SELECT ID, MD5(guid) AS guid FROM $wpdb->posts WHERE post_type='attachment' AND post_status='inherit' AND post_mime_type LIKE 'image/%';",
+			ARRAY_A
+		);
+
+		if ( $results_1 ) {
+			$results_1 = array_combine(
+				wp_list_pluck( $results_1, 'guid' ),
+				wp_list_pluck( $results_1, 'ID' )
+			);
+		} else {
+			$results_1 = array();
+		}
+
+		return $results_1;
+	}
+
+	/**
+	 * Attachment URL to Post ID - Query 2
+	 *
+	 * Unused/Conceptual function. This is intended to work solely with `aiosp_common::attachment_url_to_post_id()`.
+	 * Calling this multiple times is memory intense. It's intended to query for custom images, and data for those types
+	 * of images only exists in the postmeta database table
+	 *
+	 * @todo Investigate unserialize() memory consumption/leak.
+	 * @link https://www.evonide.com/breaking-phps-garbage-collection-and-unserialize/
+	 *
+	 * @see aiosp_common::attachment_url_to_postid()
+	 * @see unserialize()
+	 * @link http://php.net/manual/en/function.unserialize.php
+	 * @see wpdb::get_results()
+	 * @link https://developer.wordpress.org/reference/classes/wpdb/get_results/
+	 * @see wp_upload_dir()
+	 * @link https://developer.wordpress.org/reference/functions/wp_upload_dir/
+	 *
+	 * @return array
+	 */
+	public static function attachment_url_to_postid_query_2() {
+		global $wpdb;
+
+		$tmp_arr = array();
+		$results_2 = $wpdb->get_results(
+			"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE `meta_key` = '_wp_attachment_metadata' AND `meta_value` != '" . serialize( array() ) . "';",
+			ARRAY_A
+		);
+		if ( $results_2 ) {
+			for ( $i = 0; $i < count( $results_2 ); $i++ ) {
+				// TODO Investigate potentual memory leak(s); currently with unserialize.
+				$meta_value = unserialize( $results_2[ $i ]['meta_value'] );
+
+				// TODO Needs Discussion: Should this be added? To handle errors better instead of suspecting aioseop is at fault and lessen support threads.
+				/**
+				 * This currently handles "warning" notices with unserialize which normally can't be handled with a try/catch.
+				 * However, this notice should be identified and corrected; which is seperate from the plugin, but
+				 * can also triggered by the plugin.
+				 *
+				 * @see aiosp_common::error_handle_images()
+				 * @see set_error_handler()
+				 * @link http://php.net/manual/en/function.set-error-handler.php
+				 * @see restore_error_handler()
+				 * @link http://php.net/manual/en/function.restore-error-handler.php
+				 */
+				/*
+				set_error_handler( 'aiosp_common::error_handle_images' );
+				try {
+					$meta_value = unserialize( $results_2[ $i ]['meta_value'] );
+				} catch ( Exception $e ) {
+					unset( $meta_value );
+					restore_error_handler();
+					continue;
+				}
+				restore_error_handler();
+				*/
+
+				// Images and Videos use different variable structures.
+				if ( false === $meta_value || ! isset( $meta_value['file'] ) && ! isset( $meta_value['sizes'] ) ) {
+					continue;
+				}
+
+				// Set the URL => PostIDs.
+				$uploads_dir = wp_upload_dir();
+				$custom_img_base_url = $uploads_dir['baseurl'] . '/' . str_replace( basename( $meta_value['file'] ), '', $meta_value['file'] );
+				foreach ( $meta_value['sizes'] as $image_size_arr ) {
+					$tmp_arr[ md5( ( $custom_img_base_url . $image_size_arr['file'] ) ) ] = $results_2[ $i ]['post_id'];
+				}
+
+				unset( $meta_value );
+			}
+		}
+
+		$results_2 = $tmp_arr;
+		unset( $tmp_arr );
+
+		return $results_2;
+	}
+
+	/**
+	 * Error Hand Images
+	 *
+	 * Unused/Conceptual function potentually used in `aiosp_common::attachment_url_to_post_id_query_2()`.
+	 *
+	 * @see aiosp_common::attachment_url_to_post_id_query_2()
+	 *
+	 * @param $errno
+	 * @param $errstr
+	 * @param $errfile
+	 * @param $errline
+	 * @return bool
+	 * @throws ErrorException
+	 */
+	public static function error_handle_images( $errno, $errstr, $errfile, $errline ) {
+		// Possibly handle know issues differently.
+		// Handles unserialize() warning notice.
+		if ( 8 === $errno || strpos( $errstr , 'unserialize():' ) ) {
+			throw new ErrorException( $errstr, $errno, 0, $errfile, $errline );
+		} else {
+			throw new ErrorException( $errstr, $errno, 0, $errfile, $errline );
+		}
+
+		return false;
+	}
 }

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3363,23 +3363,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return array
 		 */
 		private function get_images_from_post( $post ) {
-			//
-			/**
-			 * @var array $this->post_parents_images {
-			 * Multidimensional array for 'attachment post parent' => 'images/attachments'.
-			 *     @type array $post_id {
-			 *     TODO Attachment post objects contain attachments in the same manner.
-			 *     The (parent) post object containing images.
-			 *         @type string $post_modified Stores last post modified time to compare later if a change has occurred.
-			 *         @type array  $attachment_id {
-			 *         The ID for an attachment post type.
-			 *             @type int    $id
-			 *             @type string $url
-			 *             @type string $url_content
-			 *         }
-			 *     }
-			 * }
-			 */
 			$images = array();
 
 			if ( ! aiosp_include_images() ) {
@@ -3494,11 +3477,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				foreach ( $query_step as $step ) {
 					$step_images_tmp = $this->query_post_images_step( $step, $post, $this->post_parents_images[ $post->ID ]['images'] );
 
-					foreach( $step_images_tmp as $image ) {
+					foreach ( $step_images_tmp as $image ) {
 						$step_images[ $image['id'] ] = $image;
 					}
 				}
-
 			} else {
 				$step_images = $this->query_post_images_step( $query_step, $post, $this->post_parents_images[ $post->ID ]['images'] );
 			}
@@ -3563,7 +3545,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$rtn_images = array();
 			$query_step = intval( $query_step );
 
-			switch( $query_step ) {
+			switch ( $query_step ) {
 				case 0:
 					// GET BUILT-IN ATTACHMENT OBJECTS.
 					// Query_Step 0 may include Post Thumbnails, but there are a few objects that could be miss.
@@ -3573,6 +3555,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						'post_status' => null,
 						'post_parent' => $post->ID,
 					);
+
 					$attachments = get_posts( $args );
 
 					if ( $attachments ) {
@@ -3587,8 +3570,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 									'url_content' => '',
 								);
 							}
-
-
 						}
 					}
 					wp_reset_postdata();
@@ -3645,7 +3626,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				case 2:
 					//// GET URL IMAGES FROM CONTENT.
 					$image_urls = array();
-					$content = $post->post_content;
+					$content    = $post->post_content;
 
 					// Gets Jetpack galleries.
 					// `$images` param is modified.

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3443,14 +3443,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return array
 		 */
 		private function get_image_attributes( $url ) {
-			global $wpdb;
-			$attributes = array();
-
-			$attachment = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid='%s';", $url ) );
-			if ( $attachment && is_array( $attachment ) && is_numeric( $attachment[0] ) ) {
-				$attributes = array(
-					'image:caption' => wp_get_attachment_caption( $attachment[0] ),
-					'image:title'   => get_the_title( $attachment[0] ),
+			$attributes	= array();
+			$attachment_id = aiosp_common::attachment_url_to_postid( $url );
+			if ( $attachment_id ) {
+				$attributes	= array(
+						'image:caption' => wp_get_attachment_caption( $attachment_id ),
+						'image:title' => get_the_title( $attachment_id ),
 				);
 			}
 			return $attributes;


### PR DESCRIPTION
Issue #2008

## URL to Post IDs Filter
Delete & Disable Transient Data; for testing peak performance.
```
function aioseop_remove_set_transient_url_postids() {
	remove_action( 'shutdown', 'aiosp_common::set_transient_url_postids' );
	if ( is_multisite() ) {
		delete_site_transient( 'multisite_aioseop_attachment_url_postids', self::$attachment_url_postids, 24 * HOUR_IN_SECONDS );
	} else {
		delete_transient( 'aioseop_attachment_url_postids', self::$attachment_url_postids, 24 * HOUR_IN_SECONDS );
	}
}
add_action( 'shutdown', 'aioseop_remove_set_transient_url_postids', 9 );
```

## Query Step Filter
Used to control which query steps are used.

```
/**
 * Skip heavy query step.
 *
 * @param $query_step
 * @return int
 */
function aioseop_post_images_step_1( $query_step ) {
	switch ( $query_step ) {
		case 2:
			$query_step++;
			break;
	}

	return $query_step;
}
add_filter( 'aioseop_post_images_query_step', 'aioseop_post_images_step_1' );

/**
 * Fire target query steps on every load.
 * Note: It's best not to use all 3, and value 2 is a heavy query step.
 *
 * @param $query_step
 * @return int
 */
function aioseop_post_images_step_2( $query_step ) {
	return array( 0, 1, 2 );
}
//add_filter( 'aioseop_post_images_query_step', 'aioseop_post_images_step_2' );

/**
 * On initial step ( 0 ), set the query step to target step. Default set the step as finished.
 *
 * @param $query_step
 * @return int
 */
function aioseop_post_images_step_3( $query_step ) {
	switch ( $query_step ) {
		case 0:
			$query_step = 2;
			break;
		default:
			$query_step = 3;
			break;
	}

	return $query_step;
}
//add_filter( 'aioseop_post_images_query_step', 'aioseop_post_images_step_3' );

/**
 * On initial step ( 0 ), set the query step to do all query steps. Default set the step as finished/skip.
 *
 * @param $query_step
 * @return int
 */
function aioseop_post_images_step_4( $query_step ) {
	switch ( $query_step ) {
		case 0:
			$query_step = array( 0, 1, 2 );
			break;
		default:
			$query_step = 3;
			break;
	}

	return $query_step;
}
//add_filter( 'aioseop_post_images_query_step', 'aioseop_post_images_step_4' );
```

Used to delete transient data
```
function aioseop_remove_set_transient_post_parents_images() {
	global $wpdb;
	remove_action( 'shutdown', array( 'All_in_One_SEO_Pack_Sitemap', 'set_transient_post_parents_images' ) );

	if ( is_multisite() ) {
		$wpdb->get_results( "DELETE FROM `wp_options` WHERE `option_name` LIKE ('multisite_aioseop_posts_images_%')" );
		$wpdb->get_results( "DELETE FROM `wp_options` WHERE `option_name` LIKE ('multisite_aioseop_posts_images_query_step_%')" );
	} else {
		$wpdb->get_results( "DELETE FROM `wp_options` WHERE `option_name` LIKE ('aioseop_posts_images_%')" );
		$wpdb->get_results( "DELETE FROM `wp_options` WHERE `option_name` LIKE ('aioseop_posts_images_query_step_%')" );
	}
}
add_action( 'shutdown', 'aioseop_remove_set_transient_post_parents_images', 9 );
```