### PR TITLE
Use Placeholder to make a string translatable.

### DIFF
--- a/admin/display/general-metaboxes.php
+++ b/admin/display/general-metaboxes.php
@@ -42,8 +42,11 @@ class aiosp_metaboxes {
 						<p>
 							<strong>
 								<?php
-								echo aiosp_common::get_upgrade_hyperlink( 'side', __( 'Pro Version', 'all-in-one-seo-pack' ), __( 'CLICK HERE', 'all-in-one-seo-pack' ), '_blank' );
-								echo __( ' to upgrade to Pro Version and get:', 'all-in-one-seo-pack' );
+								printf(
+									/* Translators: %s: click here */
+									__( '%s to upgrade to Pro Version and get:', 'all-in-one-seo-pack' ),
+									aiosp_common::get_upgrade_hyperlink( 'side', __( 'Pro Version', 'all-in-one-seo-pack' ), __( 'CLICK HERE', 'all-in-one-seo-pack' ), '_blank' )
+								);
 								?>
 								</strong>
 						</p>

--- a/admin/display/general-metaboxes.php
+++ b/admin/display/general-metaboxes.php
@@ -186,8 +186,11 @@ class aiosp_metaboxes {
 
 		echo '</ul>';
 
-		echo '<a href="https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/new" />Click here</a> to file a feature request/bug report.';
-
+		printf(
+			/* Translators: %s: Click here */
+			__( '%s to file a feature request/bug report.', 'all-in-one-seo-pack' ),
+			'<a href="https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/new" />' . __( 'Click here', 'all-in-one-seo-pack' ) . '</a>'
+		);
 	}
 
 }

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -862,14 +862,19 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 			$url = aioseop_home_url( '/' . $this->get_filename() . '.xml' );
 
-			/* translators: Link to documentation. */
-			$options[ $this->prefix . 'link' ]  = sprintf( __( 'Click here to %s.', 'all-in-one-seo-pack' ), '<a href="' . esc_url( $url ) . '" target="_blank">' . __( 'view your XML sitemap', 'all-in-one-seo-pack' ) . '</a>' );
-			$options[ $this->prefix . 'link' ] .= __( ' Your sitemap has been created with content and images.', 'all-in-one-seo-pack' );
+			/* Translators: %s: Click here */
+			$options[ $this->prefix . 'link' ]  = sprintf(
+				__( '%s to view your XML sitemap. Your sitemap has been created with content and images.', 'all-in-one-seo-pack' ),
+				'<a href="' . esc_url( $url ) . '" target="_blank">' . __( 'Click here', 'all-in-one-seo-pack' ) . '</a>'
+			 );
 
 			if ( $options[ "{$this->prefix}rss_sitemap" ] ) {
 				$url_rss = aioseop_home_url( '/' . $this->get_filename() . '.rss' );
-				/* translators: Link to sitemap within current site. */
-				$options[ $this->prefix . 'link' ] .= '<p>' . sprintf( __( 'Click here to %1$sview your RSS sitemap%2$s.', 'all-in-one-seo-pack' ), '<a href="' . esc_url( $url_rss ) . '" target="_blank">', '</a>' ) . '</p>';
+				/* Translators: %s: Click here */
+				$options[ $this->prefix . 'link' ] .= '<p>' . sprintf(
+					__( '%s to view your RSS sitemap.', 'all-in-one-seo-pack' ),
+					'<a href="' . esc_url( $url_rss ) . '" target="_blank">' . __( 'Click here', 'all-in-one-seo-pack' ) . '</a>'
+				) . '</p>';
 			}
 
 			if ( '0' !== get_option( 'blog_public' ) ) {


### PR DESCRIPTION
## Proposed changes

The string ` to upgrade to Pro Version and get:` hasn't finished sentence and couldn't be translated to Japanese which has different word ordering.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

I checked on my staging WP site and added a comment for translators.

## Further comments

Now I'm in a process to fix wrong translations and translation guideline errors. :) I hope more Japanese users can use your product.
https://translate.wordpress.org/locale/ja/default/wp-plugins/all-in-one-seo-pack