### PR TITLE
Fix line-broken localized help link.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 
 ---
- - [ ] I've searched for any related issues and avoided creating a duplicate issue.
+ - [ ] I understand that this is a development repository and not a support forum. This is a bug report and is not a support request.
  - [ ] I've followed the [troubleshooting steps](https://semperplugins.com/documentation/how-to-troubleshoot-issues-with-all-in-one-seo-pack)  to determine if there's a theme/plugin conflict. 
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,8 @@ about: Create a report to help us improve
 
 **Describe the bug**
 A clear and concise description of what the bug is.
+What happened?
+What did you expect to happen?
 
 **To Reproduce**
 Steps to reproduce the behavior:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,8 @@ name: Bug report
 about: Create a report to help us improve
 
 ---
+ - [ ] I've searched for any related issues and avoided creating a duplicate issue.
+ - [ ] I've followed the [troubleshooting steps](https://semperplugins.com/documentation/how-to-troubleshoot-issues-with-all-in-one-seo-pack)  to determine if there's a theme/plugin conflict. 
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Proposed changes
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+Describe the big picture of your changes here to communicate why the PR should be accepted. If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
 ## Types of changes
 

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -949,8 +949,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 						'condshow' => array( 'aiosp_disable' => 'on' ),
 					),
 				),
-				// #1067: if SEO is disabled and an empty array is passed below, it will be overriden. So let's pass a post type that cannot possibly exist.
-				'display'         => $aioseop_options['aiosp_cpostactive'],
+				// #1067: if SEO is disabled and an empty array is passed below, it will be overridden. So let's pass a post type that cannot possibly exist.
+				'display'         => ! empty( $aioseop_options['aiosp_cpostactive'] ) ? array( $aioseop_options['aiosp_cpostactive'] ) : array( '___null___' ),
 			),
 		);
 

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -4,7 +4,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for your WordPress blog. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 30 million downloads since 2007.
-Version: 2.10
+Version: 2.10.1
 Author: Michael Torbert
 Author URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Text Domain: all-in-one-seo-pack
@@ -32,14 +32,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The original WordPress SEO plugin.
  *
  * @package All-in-One-SEO-Pack
- * @version 2.10
+ * @version 2.10.1
  */
 
 if ( ! defined( 'AIOSEOPPRO' ) ) {
 	define( 'AIOSEOPPRO', false );
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '2.10' );
+	define( 'AIOSEOP_VERSION', '2.10.1' );
 }
 global $aioseop_plugin_name;
 $aioseop_plugin_name = 'All in One SEO Pack';

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -118,9 +118,7 @@ div.aioseop_tip_icon:before {
 .aioseop_meta_box_help,
 .aioseop_meta_box_help:active {
 	float: right;
-	padding-left: 0;
-	width: 16px;
-	margin-right: 32px;
+	text-align: right;
 	text-decoration: none;
 	height: 15px;
 	padding-top: 1px;

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -459,7 +459,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				'on ' !== $options[ "{$this->prefix}indexes" ] &&
 				1001 < $options[ "{$this->prefix}max_posts" ]
 			) {
-
+				$num_terms   = 0;
 				$post_counts = $this->get_total_post_count(
 					array(
 						'post_type'   => $options[ "{$this->prefix}posttypes" ],
@@ -472,7 +472,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 					$num_terms = array_sum( $term_counts );
 				}
 
-				// TODO Fix undefined variable.
 				$sitemap_urls = $post_counts + $num_terms;
 
 				if ( 1001 > $sitemap_urls ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=mrtor
 Tags: SEO, all in one seo, WordPress SEO, Google Search Console, XML Sitemap, image seo
 Requires at least: 4.4
 Tested up to: 5.0
-Stable tag: 2.10
+Stable tag: 2.10.1
 License: GPLv2 or later
 Requires PHP: 5.2.4
 


### PR DESCRIPTION
## Proposed changes

Currently help links on the next to metabox titles is overflowed when using Japanese locale. `width` attribute should be removed and accepted in any length.

![screenshot_2019_01_10_8_08](https://user-images.githubusercontent.com/1886443/50935437-55a1a500-14af-11e9-9613-e576fc23b6a0.jpg)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)