### PR TITLE
Update to aioseop_class.php to fix post_type issue

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2168,7 +2168,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 		$title_format = $this->get_post_title_format( 'post', $post );
 
-		return $this->title_placeholder_helper( $title, $post, 'post', $title_format, $category );
+		return $this->title_placeholder_helper( $title, $post, $post->post_type, $title_format, $category );
 	}
 
 	/**


### PR DESCRIPTION
Sometimes (for reasons which are not clear to me) apply_post_title_format() is called on a page or custom post type. This currently causes the title in the <head> of the page to be printed as the format (e.g. <title>%page_title% | %blog_title%</title>) instead of the parsed template.

This fix corrects that issue so that the titles are rendered correctly.

There may be better ways to fix the issue, but the logic determining how a title is rendered is complicated and this seemed like the simplest fix

## Proposed changes

Describe the big picture of your changes here to communicate why the PR should be accepted. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
