### PR TITLE
Fix href/URL output with <link> elements on paginated posts

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4480,10 +4480,12 @@ EOF;
 				}
 			}
 			if ( ! empty( $prev ) ) {
-				$prev = $this->substr( $prev, 9, - 2 );
+				$tmp_str = $this->substr( $prev, ( $this->strpos( $prev, 'href="' ) + 6 ) );
+				$prev    = $this->substr( $tmp_str, 0, ( $this->strpos( $tmp_str, '"' ) -  $this->strlen( $tmp_str ) ) );
 			}
 			if ( ! empty( $next ) ) {
-				$next = $this->substr( $next, 9, - 2 );
+				$tmp_str = $this->substr( $next, ( $this->strpos( $next, 'href="' ) + 6 ) );
+				$next    = $this->substr( $tmp_str, 0, ( $this->strpos( $tmp_str, '"' ) -  $this->strlen( $tmp_str ) ) );
 			}
 		}
 

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4473,9 +4473,13 @@ EOF;
 			}
 			if ( ! empty( $page ) ) {
 				if ( $page > 1 ) {
+					// Cannot use `wp_link_page()` since it is for rendering purposes and has no control over the page number.
+					// TODO Investigate alternate wp concept. If none is found, keep private function in case of any future WP changes.
 					$prev = _wp_link_page( $page - 1 );
 				}
 				if ( $page + 1 <= $numpages ) {
+					// Cannot use `wp_link_page()` since it is for rendering purposes and has no control over the page number.
+					// TODO Investigate alternate wp concept. If none is found, keep private function in case of any future WP changes.
 					$next = _wp_link_page( $page + 1 );
 				}
 			}

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4479,17 +4479,22 @@ EOF;
 					$next = _wp_link_page( $page + 1 );
 				}
 			}
+
+			$prev_link = '';
+			$next_link = '';
 			if ( ! empty( $prev ) ) {
-				$tmp_str = $this->substr( $prev, ( $this->strpos( $prev, 'href="' ) + 6 ) );
-				$prev    = $this->substr( $tmp_str, 0, ( $this->strpos( $tmp_str, '"' ) -  $this->strlen( $tmp_str ) ) );
+				$dom = new DOMDocument();
+				$dom->loadHTML( $prev );
+				$prev_link = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
 			}
 			if ( ! empty( $next ) ) {
-				$tmp_str = $this->substr( $next, ( $this->strpos( $next, 'href="' ) + 6 ) );
-				$next    = $this->substr( $tmp_str, 0, ( $this->strpos( $tmp_str, '"' ) -  $this->strlen( $tmp_str ) ) );
+				$dom = new DOMDocument();
+				$dom->loadHTML( $next );
+				$next_link = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
 			}
 		}
 
-		return array( 'prev' => $prev, 'next' => $next );
+		return array( 'prev' => $prev_link, 'next' => $next_link );
 	}
 
 	/**

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4480,21 +4480,19 @@ EOF;
 				}
 			}
 
-			$prev_link = '';
-			$next_link = '';
 			if ( ! empty( $prev ) ) {
 				$dom = new DOMDocument();
 				$dom->loadHTML( $prev );
-				$prev_link = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
+				$prev = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
 			}
 			if ( ! empty( $next ) ) {
 				$dom = new DOMDocument();
 				$dom->loadHTML( $next );
-				$next_link = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
+				$next = $dom->getElementsByTagName( 'a' )->item(0)->getAttribute( 'href' );
 			}
 		}
 
-		return array( 'prev' => $prev_link, 'next' => $next_link );
+		return array( 'prev' => $prev, 'next' => $next );
 	}
 
 	/**


### PR DESCRIPTION
Issue #2189

## Commit Description

WP 5.1 introduced the issue by adding a new CSS class name to prev & next links.

Accessibility: use `aria-current` for the paginated post links output…

https://github.com/WordPress/wordpress-develop/commit/1258d1d9d2c7bef7c18b4e3420219cfa716d0aca

https://core.trac.wordpress.org/ticket/41859

