### PR TITLE
Update opengraph fb_object_type field to Fix issue 2227 

### DIFF
--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -956,23 +956,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			}
 			foreach ( $options as $k => $v ) {
 				switch ( $k ) {
-					case $prefix . 'category':
-						if ( empty( $v ) ) {
-							// Get post type
-							$type = isset( get_current_screen()->post_type )
-								? get_current_screen()->post_type
-								: null;
-							// Assign default from plugin options
-							if ( ! empty( $type )
-								&& isset( $aioseop_options['modules'] )
-								&& isset( $aioseop_options['modules']['aiosp_opengraph_options'] )
-								&& isset( $aioseop_options['modules']['aiosp_opengraph_options'][ 'aiosp_opengraph_' . $type . '_fb_object_type' ] )
-							) {
-								$options[ $prefix . 'category' ] =
-									$aioseop_options['modules']['aiosp_opengraph_options'][ 'aiosp_opengraph_' . $type . '_fb_object_type' ];
-							}
-						}
+					/*
+					case $prefix . 'example':
+						//override value if needed
 						break;
+					*/
 				}
 				if ( $v === null ) {
 					unset( $options[ $k ] );

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -873,7 +873,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 						}
 						$settings[ $prefix . 'category' ]['initial_options'] = array_merge(
 							array(
-								$this->options[ "aiosp_opengraph_{$current_post_type}_fb_object_type" ] => __( 'Default ', 'all-in-one-seo-pack' ) . ' - '
+								$this->options[ "" ] => __( 'Default ', 'all-in-one-seo-pack' ) . ' - '
 																										 . $flat_type_list[ $this->options[ "aiosp_opengraph_{$current_post_type}_fb_object_type" ] ],
 							),
 							$settings[ $prefix . 'category' ]['initial_options']


### PR DESCRIPTION
## Fixed Issue #2227 : Changing default OG:Type doesn't affect posts

## Cause of this issue
- Facebook object type ( `aioseop_opengraph_settings_category` ) field causes the issue
- Value of first default item of the field is duplicate of another value. So when user select default value and submit then the selection is overridden by another option. Value of default item should be blank.
- When the value of the field is blank then it is being populated by the default value from the plugin option.

## Solution
- I set blank value for the default item.
- Removed a block of code to stop assigning default value from plugin option.
