### PR TITLE
Facebook SSL og:image only works if they have a non-SSL version cached

### DIFF
--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1485,6 +1485,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 				$meta['google+'] = array( 'thumbnail' => 'image' );
 			}
 
+			// https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/1848
+			if ( is_ssl() ) {
+				$meta['facebook'] += array( 'thumbnail_1' => 'og:image:secure_url' );
+				$thumbnail_1 = $thumbnail;
+			}
+
 			$tags = array(
 				'facebook' => array( 'name' => 'property', 'value' => 'content' ),
 				'twitter'  => array( 'name' => 'name', 'value' => 'content' ),


### PR DESCRIPTION
#1848 