### PR TITLE
Change Sitemap to exclude NOINDEX post types & posts

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4251,22 +4251,19 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 			$this->excludes = array_merge( $args['exclude'], $exclude_slugs ); // Add excluded slugs and IDs to class var.
 
-			$post_types = $args['post_type'];
 			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
-				if ( is_array( $post_types ) ) {
-					foreach ( $post_types as $index => $post_type ) {
+				if ( is_array( $args['post_type'] ) ) {
+					foreach ( $args['post_type'] as $index => $post_type ) {
 						if ( in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
-							unset( $post_types[ $index ] );
+							unset( $args['post_type'][ $index ] );
 						}
 					}
 				} else {
-					if ( in_array( $post_types, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
+					if ( in_array( $args['post_type'], $aioseop_options['aiosp_cpostnoindex'], true ) ) {
 						return array();
 					}
 				}
-
 			}
-			$args['post_type'] = $post_types;
 
 			// TODO: consider using WP_Query instead of get_posts to improve efficiency.
 			$posts = get_posts( apply_filters( $this->prefix . 'post_query', $args ) );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4283,7 +4283,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			);
 
 			// Exclude from main query, and check if a Query Include is needed.
+			// Check for NoIndex Post Types.
 			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
+				// Check if wp_query_args post_type is an array or string.
 				if ( is_array( $args['post_type'] ) ) {
 					foreach ( $args['post_type'] as $index => $post_type ) {
 						if ( in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'], true ) ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4242,6 +4242,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$args['exclude'] = explode( ',', $args['exclude'] );
 			}
 
+			// Exclude (method) query args.
 			$ex_args                   = $args;
 			$ex_args['meta_query']     = array(
 				'relation' => 'OR',
@@ -4259,13 +4260,16 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			);
 			$ex_args['fields']         = 'ids';
 			$ex_args['posts_per_page'] = - 1;
+
+			// Exclude (method) query.
 			$q_exclude                 = new WP_Query( $ex_args );
 			if ( ! empty( $q_exclude->posts ) ) {
 				$args['exclude'] = array_merge( $args['exclude'], $q_exclude->posts );
 			}
 			$this->excludes = array_merge( $args['exclude'], $exclude_slugs ); // Add excluded slugs and IDs to class var.
 
-			// Include query args for including posts that may have been excluded;
+			// Avoid if possible.
+			// Include (method) query args for including posts that may have been excluded;
 			// for example, exclude post type, but include certain posts.
 			// NOTE: Do NOT use this for basic including. It's best to avoid an additional query.
 			$args_include = array(
@@ -4283,7 +4287,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			);
 
 			// Exclude from main query, and check if a Query Include is needed.
-			// Check for NoIndex Post Types.
+			// Check for NoIndex Post Types, BUT also check for Index on NoIdex Post Type.
 			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
 				// Check if wp_query_args post_type is an array or string.
 				if ( is_array( $args['post_type'] ) ) {
@@ -4298,14 +4302,19 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						$args_include['post_type'][] = $args['post_type'];
 
 						$q_include = new WP_Query( $args_include );
+						// Return posts on single post type query, since no additional query is needed.
 						return $q_include->posts;
 					}
 				}
 			}
 
+			// Avoid if possible.
+			// Include (method) query.
+			// NOTE: Do NOT use this for basic including. It's best to avoid an additional query.
 			$posts_include = array();
 			if ( ! empty( $args_include['post_type'] ) ) {
 				$q_include = new WP_Query( $args_include );
+				// When posts exists from the include method, add to $posts_include to add to final query.
 				if ( ! empty( $q_include->posts ) ) {
 					$posts_include = $q_include->posts;
 				}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4251,13 +4251,20 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 			$this->excludes = array_merge( $args['exclude'], $exclude_slugs ); // Add excluded slugs and IDs to class var.
 
-			$post_types = $this->options[ "{$this->prefix}posttypes" ];
+			$post_types = $args['post_type'];
 			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
-				foreach ( $post_types as $index => $post_type ) {
-					if ( in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
-						unset( $post_types[ $index ] );
+				if ( is_array( $post_types ) ) {
+					foreach ( $post_types as $index => $post_type ) {
+						if ( in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
+							unset( $post_types[ $index ] );
+						}
+					}
+				} else {
+					if ( in_array( $post_types, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
+						return array();
 					}
 				}
+
 			}
 			$args['post_type'] = $post_types;
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4259,7 +4259,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				),
 			);
 			$ex_args['fields']         = 'ids';
-			$ex_args['posts_per_page'] = - 1;
+			$ex_args['posts_per_page'] = $this->max_posts;
 
 			// Exclude (method) query.
 			$q_exclude                 = new WP_Query( $ex_args );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4171,6 +4171,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return array|mixed
 		 */
 		public function get_all_post_type_data( $args ) {
+			global $aioseop_options;
 			$defaults = array(
 				'numberposts'   => $this->max_posts,
 				'offset'        => 0,
@@ -4244,6 +4245,16 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$args['exclude'] = array_merge( $args['exclude'], $q->posts );
 			}
 			$this->excludes = array_merge( $args['exclude'], $exclude_slugs ); // Add excluded slugs and IDs to class var.
+
+			$post_types = $this->options[ "{$this->prefix}posttypes" ];
+			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
+				foreach ( $post_types as $index => $post_type ) {
+					if ( in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'], true ) ) {
+						unset( $post_types[ $index ] );
+					}
+				}
+			}
+			$args['post_type'] = $post_types;
 
 			// TODO: consider using WP_Query instead of get_posts to improve efficiency.
 			$posts = get_posts( apply_filters( $this->prefix . 'post_query', $args ) );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1881,6 +1881,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 			$files[] = array( 'loc' => aioseop_home_url( '/' . $prefix . '_addl' . $suffix ) );
 
+			// Get post types selected, and prevent NoIndex post types.
 			$post_types = $options[ "{$this->prefix}posttypes" ];
 			if ( is_array( $aioseop_options['aiosp_cpostnoindex'] ) ) {
 				foreach ( $post_types as $index => $post_type ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1910,10 +1910,23 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( ! empty( $post_types ) ) {
 				$prio        = $this->get_default_priority( 'post' );
 				$freq        = $this->get_default_frequency( 'post' );
+				// Get post counts from posts type. Exclude if NoIndex is on.
 				$post_counts = $this->get_all_post_counts(
 					array(
 						'post_type'   => $post_types,
 						'post_status' => 'publish',
+						'meta_query'     => array(
+							'relation'   => 'OR',
+							array(
+								'key'     => '_aioseop_noindex',
+								'value'   => 'on',
+								'compare' => '!=',
+							),
+							array(
+								'key'     => '_aioseop_noindex',
+								'compare' => 'NOT EXISTS',
+							),
+						),
 					)
 				);
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3863,7 +3863,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$args['category'] = implode( ',', $cats );
 			}
 			if ( $this->option_isset( 'excl_pages' ) ) {
-				// TODO Change/fix to exclude correctly. There is no arg['exclude'].
 				$args['exclude'] = $this->options[ $this->prefix . 'excl_pages' ];
 			}
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1900,7 +1900,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							'posts_per_page' => 1,
 						);
 						$q = new WP_Query( $args );
-						if ( ! $q->post_count ) {
+						if ( 0 === $q->post_count ) {
 							unset( $post_types[ $index ] );
 						}
 					}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1856,6 +1856,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * @since 2.3.6
 		 * @since 2.3.12.3 Refactored to use aioseop_home_url() for compatibility purposes.
+		 * @since 3.0 Changed to exclude noindex post types. #1382
 		 *
 		 * @return array
 		 */
@@ -4166,8 +4167,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Return post data using get_posts().
 		 *
-		 * @param $args
+		 * @since ?
+		 * @since 3.0 Changed to exclude noindex post types & posts. #1382
 		 *
+		 * @global array $aioseop_options
+		 *
+		 * @param array $args Query Arguments.
 		 * @return array|mixed
 		 */
 		public function get_all_post_type_data( $args ) {


### PR DESCRIPTION
Issue #1382

~~Related to~~ Replaces (edited by Michael) PR: Remove from sitemap when noindex is enabled #2264

# Proposed Changes

Keeps the sitemap from displaying post types and posts that use NOINDEX settings.

## Steps

1) Activate plugin.
2) Go to Sitemap settings.
    b) Enable/Disable Sitemap Indexes.
    a) Select the Post Types to add to sitemap.
3) Go to General settings (under Noindex settings), and select which Post Types to NOINDEX.
4) Navigate to the sitemap.xml (link is located in Sitemap settings).
5) Repeat steps 2-4 to test for different configurations.