### PR TITLE
PHPCS checks for strict comparsion

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,12 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added necessary documentation (if appropriate)
 
+## Testing instructions
+-Don't assume the tester knows the entire backstory of the issue, and don't force him/her to decipher the code to try and figure out what -it's doing or how to test it.
+-Do provide step by step instructions on how to test. 
+-Do note things to watch out for.
+-Do not what aspects the tester should try and break.
+
 ## Further comments
 
 If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -48,6 +48,13 @@
         <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
         <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
 
+        <!-- these can be removed once #2335 is closed -->
+        <exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
+        <exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found" />
+        <exclude name="WordPress.PHP.StrictComparisons.LooseComparison" />
+        <exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
+
+
     </rule>
     <rule ref="WordPress-Docs">
     </rule>


### PR DESCRIPTION
#2335 

I have excluded the rules that were causing grunt to fail. Some of them have been marked by Ben as TODOs previously so it would be good to fix them in this/a subsequent release. This change will be similar to the grunt change where a number of files were affected so we may want to discuss this.

This should be merged into the development branch so that all PRs successfully pass grunt