### PR TITLE
Remove support for WP < 4.7 

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -890,6 +890,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @since 2.3.6
 		 * @since 2.3.12.3 Refactored to use aioseop_home_url() for compatibility purposes.
 		 * @since 3.0 Change 'excl_terms' to include taxonomy slugs with term id. (Pro #240)
+		 * @since 3.0 Remove WP < 3.5 old Privacy Settings link
 		 *
 		 * @param $options
 		 *

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3445,8 +3445,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return array
 		 */
 		private function get_images_from_term( $term ) {
-			global $wp_version;
-
 			if ( ! aiosp_include_images() ) {
 				return array();
 			}
@@ -3854,6 +3852,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @since 2.4.1
 		 * @since 2.4.3 Compatibility with Pre v4.7 wp_parse_url().
 		 * @since 2.11 Sitemap Optimization #2008 - Changed to a more appropriate name.
+		 * @since 3.0 remove checks for old WP versions
 		 *
 		 * @return bool
 		 */

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3439,6 +3439,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @param WP_Term $term the term object.
 		 *
 		 * @since 2.4
+		 * @since 3.0 remove check for WP 4.4
 		 *
 		 * @return array
 		 */
@@ -3450,18 +3451,16 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			$images = array();
-			// the table term meta table is not defined for lower versions.
-			if ( version_compare( $wp_version, '4.4.0', '>=' ) ) {
-				$thumbnail_id = get_term_meta( $term->term_id, 'thumbnail_id', true );
-				if ( $thumbnail_id ) {
-					$image = wp_get_attachment_url( $thumbnail_id );
-					if ( $image ) {
-						$images['image:image'] = array(
-							'image:loc'     => $image,
-							'image:caption' => wp_get_attachment_caption( $thumbnail_id ),
-							'image:title'   => get_the_title( $thumbnail_id ),
-						);
-					}
+
+			$thumbnail_id = get_term_meta( $term->term_id, 'thumbnail_id', true );
+			if ( $thumbnail_id ) {
+				$image = wp_get_attachment_url( $thumbnail_id );
+				if ( $image ) {
+					$images['image:image'] = array(
+						'image:loc'     => $image,
+						'image:caption' => wp_get_attachment_caption( $thumbnail_id ),
+						'image:title'   => get_the_title( $thumbnail_id ),
+					);
 				}
 			}
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3414,7 +3414,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						$timestamp      = mysql2date( 'U', $post->post_modified_gmt );
 						$pr_info['rss'] = array(
 							'title'       => $title,
-							'description' => $this->get_the_excerpt( $post ),
+							'description' => get_the_excerpt( $post ),
 							'pubDate'     => date( 'r', $timestamp ),
 							'timestamp  ' => $timestamp,
 							'post_type'   => $post->post_type,
@@ -3431,31 +3431,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			return $prio;
-		}
-
-		/**
-		 * Return the excerpt of the given post.
-		 *
-		 * @param WP_Post $post The post object.
-		 *
-		 * @return string
-		 */
-		private function get_the_excerpt( $post ) {
-			global $wp_version;
-			if ( has_excerpt( $post->ID ) ) {
-				if ( version_compare( $wp_version, '4.5.0', '>=' ) ) {
-					return get_the_excerpt( $post );
-				}
-
-				$text = strip_shortcodes( $post->post_content );
-				$text = apply_filters( 'the_content', $text );
-				$text = str_replace( ']]>', ']]&gt;', $text );
-
-				$excerpt_length = apply_filters( 'excerpt_length', 55 );
-				$excerpt_more   = apply_filters( 'excerpt_more', '[&hellip;]' );
-				return wp_trim_words( $text, $excerpt_length, $excerpt_more );
-			}
-			return '';
 		}
 
 		/**

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3858,29 +3858,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return bool
 		 */
 		public function is_image_url_valid( $image ) {
-			global $wp_version;
-
 			// Bail if empty image.
 			if ( empty( $image ) ) {
 				return false;
 			}
 
-			global $wp_version;
-			if ( version_compare( $wp_version, '4.4', '<' ) ) {
-				// TODO Change to wp_parse_url().
-				$p_url = parse_url( $image );
-				$url   = $p_url['scheme'] . $p_url['host'] . $p_url['path'];
-			} elseif ( version_compare( $wp_version, '4.7', '<' ) ) {
-				// Compatability for older WP version that don't have 4.7 changes.
-				// @link https://core.trac.wordpress.org/changeset/38726
-				$p_url = wp_parse_url( $image );
-				$url   = $p_url['scheme'] . $p_url['host'] . $p_url['path'];
-			} else {
-				$component = PHP_URL_PATH;
-				$url       = wp_parse_url( $image, $component );
-			}
+			$component = PHP_URL_PATH;
+			$url       = wp_parse_url( $image, $component );
 
-			// make the url absolute, if its relative.
+			// Make the url absolute, if its relative.
 			$image   = aiosp_common::absolutize_url( $image );
 			// TODO Change to wp_parse_url().
 			$extn    = pathinfo( parse_url( $image, PHP_URL_PATH ), PATHINFO_EXTENSION );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -927,12 +927,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				}
 			}
 			if ( ! get_option( 'blog_public' ) ) {
-				global $wp_version;
-				if ( version_compare( $wp_version, '3.5.0', '>=' ) || function_exists( 'set_url_scheme' ) ) {
-					$privacy_link = '<a href="options-reading.php">' . __( 'Reading Settings', 'all-in-one-seo-pack' ) . '</a>';
-				} else {
-					$privacy_link = '<a href="options-privacy.php">' . __( 'Privacy Settings', 'all-in-one-seo-pack' ) . '</a>';
-				}
+				$privacy_link = '<a href="options-reading.php">' . __( 'Reading Settings', 'all-in-one-seo-pack' ) . '</a>';
 				/* translators: Link to settings to disable "Discourage search engines from indexing this site". */
 				$options[ $this->prefix . 'link' ] .= '<p class="aioseop_error_notice">' . sprintf( __( 'Warning: your privacy settings are configured to ask search engines to not index your site; you can change this under %s for your site.', 'all-in-one-seo-pack' ), $privacy_link );
 			}


### PR DESCRIPTION
## Issue

#2311 

## Proposed changes

In 3.0, we're dropping support for WordPress versions older than 4.7. 

## Types of changes

What types of changes does your code introduce?
These instances were just calling the wp_version global with a version_compare inside an IF statement, so I just removed that portion.

During the code review, we'll want to make sure I didn't change the logic for the expected functionality.

## Testing instructions
Changes were in four places.

1. Privacy settings link in the notice.
2. Removed our custom get_the_excerpt() function in the RSS sitemap's description field.
3. This one is code that gets images for terms in the XML sitemap.
4. This deals with getting images from the post for the XML sitemap.

## Further comments

I've only changed the ones with the existence of the global $wp_version and version_compare(), but there may be more things we've done throughout the code to accomodate older versions. 