### PR TITLE
Default to sitemap indexes and 1000 posts per sitemap file

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -181,7 +181,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 					),
 					'default'         => 0,
 				),
-				'indexes'     => array( 'name' => __( 'Enable Sitemap Indexes', 'all-in-one-seo-pack' ) ),
+				'indexes'     => array(
+					'name' => __( 'Enable Sitemap Indexes', 'all-in-one-seo-pack' ),
+					'default' => 'on',
+				),
 				'max_posts'   => array(
 					'name'     => __( 'Maximum Posts Per Sitemap Page', 'all-in-one-seo-pack' ),
 					'type'     => 'text',

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1235,8 +1235,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							do {
 								$ren_to = $ren_file . '._' . sprintf( '%03d', $count ) . '.old';
 								$count ++;
-							} while ( $this->file_exists( $ren_to ) && ( $count < 50000 ) );
-							if ( $count >= 50000 ) {
+							} while ( $this->file_exists( $ren_to ) && ( $count < 1000 ) );
+							if ( $count >= 1000 ) {
 								/* translators: Shows which sitemap files couldn't be renamed. */
 								$msg .= '<p>' . sprintf( __( "Couldn't rename file %s!", 'all-in-one-seo-pack' ), $ren_file ) . '</p>';
 							} else {
@@ -2530,7 +2530,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return;
 			}
 
-			$max_items = 5000;
+			$max_items = 50000;
 			if ( ! is_array( $urls ) ) {
 				return null;
 			}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -903,8 +903,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( is_multisite() ) {
 				$options[ $this->prefix . 'rewrite' ] = 'On';
 			}
-			if ( isset( $options[ $this->prefix . 'max_posts' ] ) && ( ( $options[ $this->prefix . 'max_posts' ] <= 0 ) || ( $options[ $this->prefix . 'max_posts' ] >= 1000 ) ) ) {
-				$options[ $this->prefix . 'max_posts' ] = 1000;
+			if ( isset( $options[ $this->prefix . 'max_posts' ] ) && ( ( $options[ $this->prefix . 'max_posts' ] <= 0 ) || ( $options[ $this->prefix . 'max_posts' ] >= 50000 ) ) ) {
+				$options[ $this->prefix . 'max_posts' ] = 50000;
 			}
 			$url = aioseop_home_url( '/' . $this->get_filename() . '.xml' );
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @since ?
 		 * @var int
 		 */
-		public $max_posts = 50000;
+		public $max_posts = 1000;
 
 		/**
 		 * Priority
@@ -188,7 +188,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				'max_posts'   => array(
 					'name'     => __( 'Maximum Posts Per Sitemap Page', 'all-in-one-seo-pack' ),
 					'type'     => 'text',
-					'default'  => 50000,
+					'default'  => 1000,
 					'condshow' => array(
 						"{$this->prefix}indexes" => 'on',
 						"{$this->prefix}indexes" => 'on',
@@ -614,7 +614,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			// Load initial options / set defaults.
 			$this->update_options();
 			if ( ! empty( $this->options[ "{$this->prefix}indexes" ] ) ) {
-				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 50000 ) ) {
+				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 1000 ) ) {
 					$this->max_posts = $this->options[ "{$this->prefix}max_posts" ];
 				}
 			}
@@ -903,8 +903,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( is_multisite() ) {
 				$options[ $this->prefix . 'rewrite' ] = 'On';
 			}
-			if ( isset( $options[ $this->prefix . 'max_posts' ] ) && ( ( $options[ $this->prefix . 'max_posts' ] <= 0 ) || ( $options[ $this->prefix . 'max_posts' ] >= 50000 ) ) ) {
-				$options[ $this->prefix . 'max_posts' ] = 50000;
+			if ( isset( $options[ $this->prefix . 'max_posts' ] ) && ( ( $options[ $this->prefix . 'max_posts' ] <= 0 ) || ( $options[ $this->prefix . 'max_posts' ] >= 1000 ) ) ) {
+				$options[ $this->prefix . 'max_posts' ] = 1000;
 			}
 			$url = aioseop_home_url( '/' . $this->get_filename() . '.xml' );
 
@@ -1775,13 +1775,13 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			if ( ! empty( $this->options[ "{$this->prefix}indexes" ] ) ) {
-				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 50000 ) ) {
+				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 1000 ) ) {
 					$this->max_posts = $this->options[ "{$this->prefix}max_posts" ];
 				} else {
-					$this->max_posts = 50000;
+					$this->max_posts = 1000;
 				}
 			} else {
-				$this->max_posts = 50000;
+				$this->max_posts = 1000;
 			}
 			if ( ! $this->options[ "{$this->prefix}rewrite" ] ) {
 				if ( $this->options[ "{$this->prefix}indexes" ] ) {
@@ -2530,7 +2530,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return;
 			}
 
-			$max_items = 50000;
+			$max_items = 1000;
 			if ( ! is_array( $urls ) ) {
 				return null;
 			}
@@ -2647,7 +2647,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return null
 		 */
 		public function output_sitemap_index( $urls, $comment = '' ) {
-			$max_items = 50000;
+			$max_items = 1000;
 			if ( ! is_array( $urls ) ) {
 				return null;
 			}
@@ -4022,7 +4022,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_date_archive_prio_data() {
 			$args  = array(
-				'numberposts' => 50000,
+				'numberposts' => 1000,
 				'post_type'   => 'post',
 			);
 			$args  = $this->set_post_args( $args );
@@ -4038,7 +4038,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_author_prio_data() {
 			$args  = array(
-				'numberposts' => 50000,
+				'numberposts' => 1000,
 				'post_type'   => 'post',
 			);
 			$args  = $this->set_post_args( $args );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @since ?
 		 * @var int
 		 */
-		public $max_posts = 1000;
+		public $max_posts = 50000;
 
 		/**
 		 * Priority

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -614,7 +614,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			// Load initial options / set defaults.
 			$this->update_options();
 			if ( ! empty( $this->options[ "{$this->prefix}indexes" ] ) ) {
-				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 1000 ) ) {
+				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 50000 ) ) {
 					$this->max_posts = $this->options[ "{$this->prefix}max_posts" ];
 				}
 			}
@@ -1235,8 +1235,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							do {
 								$ren_to = $ren_file . '._' . sprintf( '%03d', $count ) . '.old';
 								$count ++;
-							} while ( $this->file_exists( $ren_to ) && ( $count < 1000 ) );
-							if ( $count >= 1000 ) {
+							} while ( $this->file_exists( $ren_to ) && ( $count < 50000 ) );
+							if ( $count >= 50000 ) {
 								/* translators: Shows which sitemap files couldn't be renamed. */
 								$msg .= '<p>' . sprintf( __( "Couldn't rename file %s!", 'all-in-one-seo-pack' ), $ren_file ) . '</p>';
 							} else {
@@ -1775,13 +1775,13 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			if ( ! empty( $this->options[ "{$this->prefix}indexes" ] ) ) {
-				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 1000 ) ) {
+				if ( $this->options[ "{$this->prefix}max_posts" ] && ( $this->options[ "{$this->prefix}max_posts" ] > 0 ) && ( $this->options[ "{$this->prefix}max_posts" ] < 50000 ) ) {
 					$this->max_posts = $this->options[ "{$this->prefix}max_posts" ];
 				} else {
-					$this->max_posts = 1000;
+					$this->max_posts = 50000;
 				}
 			} else {
-				$this->max_posts = 1000;
+				$this->max_posts = 50000;
 			}
 			if ( ! $this->options[ "{$this->prefix}rewrite" ] ) {
 				if ( $this->options[ "{$this->prefix}indexes" ] ) {
@@ -2530,7 +2530,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return;
 			}
 
-			$max_items = 1000;
+			$max_items = 5000;
 			if ( ! is_array( $urls ) ) {
 				return null;
 			}
@@ -2647,7 +2647,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return null
 		 */
 		public function output_sitemap_index( $urls, $comment = '' ) {
-			$max_items = 1000;
+			$max_items = 50000;
 			if ( ! is_array( $urls ) ) {
 				return null;
 			}
@@ -4022,7 +4022,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_date_archive_prio_data() {
 			$args  = array(
-				'numberposts' => 1000,
+				'numberposts' => 50000,
 				'post_type'   => 'post',
 			);
 			$args  = $this->set_post_args( $args );
@@ -4038,7 +4038,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_author_prio_data() {
 			$args  = array(
-				'numberposts' => 1000,
+				'numberposts' => 50000,
 				'post_type'   => 'post',
 			);
 			$args  = $this->set_post_args( $args );


### PR DESCRIPTION
## Issue 

#1929 #2257 

## Proposed changes

For some large sites, our sitemap code can't efficiently run. As we add more functionality to the sitemap, this will only get worse. The best solution to this is to use sitemap indexes.
Long term, we'll probably want to use indexes exclusively, but for now, we can just default to them on and use only 1000 posts per sitemap file.

## Types of changes

This should only change the defaults. If a person has saved new settings, it shouldn't change anything. 

## Testing instructions
- Make sure to test on an existing site as well as a brand new site.
- The defaults should be index=on and posts per file = 1000.

##Further comments
- The behavior of our settings are that defaults aren't saved to the db if the site admin hasn't clicked "update options". This means that even on an existing install, the defaults will change if they haven't ever clicked the update button. This isn't necessarily desired behavior, but it is expected behavior.