### PR TITLE
remove sitemap compression #534

### DIFF
--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -709,7 +709,6 @@ class AIOSEOP_Helper {
 			'aiosp_sitemap_archive'         => __( 'Include Date Archives in your sitemap.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_author'          => __( 'Include Author Archives in your sitemap.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_images'          => __( 'Exclude Images in your sitemap.', 'all-in-one-seo-pack' ),
-			'aiosp_sitemap_gzipped'         => __( 'Create a compressed sitemap file in .xml.gz format.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_robots'          => __( 'Places a link to your Sitemap.xml into your virtual Robots.txt file.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_rewrite'         => __( 'Dynamically creates the XML sitemap instead of using a static file.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_addl_url'        => __( 'URL to the page. This field accepts relative URLs or absolute URLs with the protocol specified.', 'all-in-one-seo-pack' ),
@@ -771,7 +770,6 @@ class AIOSEOP_Helper {
 			'aiosp_sitemap_archive'         => 'https://semperplugins.com/documentation/xml-sitemaps-module/#include-archive-pages',
 			'aiosp_sitemap_author'          => 'https://semperplugins.com/documentation/xml-sitemaps-module/#include-archive-pages',
 			'aiosp_sitemap_images'          => 'https://semperplugins.com/documentation/xml-sitemaps-module/#exclude-images',
-			'aiosp_sitemap_gzipped'         => 'https://semperplugins.com/documentation/xml-sitemaps-module/#create-compressed-sitemap',
 			'aiosp_sitemap_robots'          => 'https://semperplugins.com/documentation/xml-sitemaps-module/#link-from-virtual-robots',
 			'aiosp_sitemap_rewrite'         => 'https://semperplugins.com/documentation/xml-sitemaps-module/#dynamically-generate-sitemap',
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1494,10 +1494,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		/**
 		 * Stop timing and log memory usage for debug info.
 		 *
+		 * @since ?
+		 * @since 3.0 Removed $compressed in issue #534
+		 *
 		 * @param string $sitemap_type
 		 * @param bool   $dynamic
-		 *
-		 * @since 3.0 Removed $compressed in issue #534
 		 */
 		public function log_stats( $sitemap_type = 'static', $dynamic = true ) {
 			$time                 = timer_stop();
@@ -1777,8 +1778,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * @param $filename
 		 * @param $contents
-		 *
-		 * @since 3.0 Removed $gzip in issue #534
 		 */
 		public function write_sitemaps( $filename, $contents, $extn = '.xml' ) {
 			$this->write_sitemap( $filename . $extn, $contents );
@@ -1788,6 +1787,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * Write single sitemap.
 		 *
 		 * Write a single sitemap to the filesystem.
+		 *
+		 * @since ?
+		 * @since 3.0 Removed $gzip in issue #534
 		 *
 		 * @param      $filename
 		 * @param      $contents

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1496,6 +1496,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * @param string $sitemap_type
 		 * @param bool   $dynamic
+		 *
+		 * @since 3.0 Removed $compressed in issue #534
 		 */
 		public function log_stats( $sitemap_type = 'static', $dynamic = true ) {
 			$time                 = timer_stop();
@@ -1775,6 +1777,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * @param $filename
 		 * @param $contents
+		 *
+		 * @since 3.0 Removed $gzip in issue #534
 		 */
 		public function write_sitemaps( $filename, $contents, $extn = '.xml' ) {
 			$this->write_sitemap( $filename . $extn, $contents );


### PR DESCRIPTION
## Issue

#534 

## Proposed changes

Because compression doesn't really add much value, and has caused nothing but problems (for instance with nginx), we've decided to remove the functionality completely.
Browsing to a compressed URL should fall back to the uncompressed sitemap.

## Types of changes

What types of changes does your code introduce?

-Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing instructions
-existing installs with compression enabled with indexes
-existing installs with compression enabled without indexes
-existing installs w/o compression enabled with indexes
-existing installs w/o compression enabled without indexes
-new installs
-full testing of the sitemap functionality

## Further comments

We need to make a note to include mention of this in the release post, as people may want to re-submit their sitemap to Google (though it isn't necessary).