### PR TITLE
make social user profile fields more obviously from aioseop 

### DIFF
--- a/css/aiosp_admin.css
+++ b/css/aiosp_admin.css
@@ -76,11 +76,11 @@ li#wp-admin-bar-aioseop-pro-upgrade a.ab-item {
 	font-size: 105%;
 }
 
-label[for=aioseop_title]
+label[for=aioseop_edit_profile_header]
 {
 	font-size: 1.3em;
 }
 
-#aioseop_title {
+#aioseop_edit_profile_header {
 	display: none;
 }

--- a/css/aiosp_admin.css
+++ b/css/aiosp_admin.css
@@ -75,3 +75,12 @@ li#wp-admin-bar-aioseop-pro-upgrade a.ab-item {
 	color: #d54e21;
 	font-size: 105%;
 }
+
+label[for=aioseop_title]
+{
+	font-size: 1.3em;
+}
+
+#aioseop_title {
+	display: none;
+}

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -849,9 +849,15 @@ if ( ! function_exists( 'aioseop_add_contactmethods' ) ) {
 	 */
 	function aioseop_add_contactmethods( $contactmethods ) {
 		global $aioseop_options, $aioseop_modules;
+
 		if ( ! empty( $aioseop_modules ) && is_object( $aioseop_modules ) ) {
 			$m = $aioseop_modules->return_module( 'All_in_One_SEO_Pack_Opengraph' );
 			if ( ( $m !== false ) && is_object( $m ) ) {
+
+				if ( $m->option_isset( 'twitter_creator' ) || $m->option_isset( 'facebook_author' ) ) {
+					$contactmethods['aioseop_title'] = __( 'All in One SEO Pack', 'all-in-one-seo-pack' );
+				}
+
 				if ( $m->option_isset( 'twitter_creator' ) ) {
 					$contactmethods['twitter'] = __( 'Twitter', 'all-in-one-seo-pack' );
 				}
@@ -860,7 +866,6 @@ if ( ! function_exists( 'aioseop_add_contactmethods' ) ) {
 				}
 			}
 		}
-
 		return $contactmethods;
 	}
 }

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -855,7 +855,7 @@ if ( ! function_exists( 'aioseop_add_contactmethods' ) ) {
 			if ( ( $m !== false ) && is_object( $m ) ) {
 
 				if ( $m->option_isset( 'twitter_creator' ) || $m->option_isset( 'facebook_author' ) ) {
-					$contactmethods['aioseop_title'] = __( 'All in One SEO Pack', 'all-in-one-seo-pack' );
+					$contactmethods['aioseop_edit_profile_header'] = __( 'All in One SEO Pack', 'all-in-one-seo-pack' );
 				}
 
 				if ( $m->option_isset( 'twitter_creator' ) ) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/semperfiwebdesign/all-in-one-seo-pack#readme",
   "devDependencies": {
-    "grunt": "^1.0.2",
-    "grunt-contrib-uglify": "^3.1.0",
+    "grunt": "^1.0.4",
+    "grunt-contrib-uglify": "^3.4.0",
     "grunt-eslint": "^21.0.0",
     "grunt-mkdir": "^1.0.0",
     "grunt-phpcbf": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/semperfiwebdesign/all-in-one-seo-pack#readme",
   "devDependencies": {
-    "grunt": "^1.0.4",
-    "grunt-contrib-uglify": "^3.4.0",
+    "grunt": "^1.0.2",
+    "grunt-contrib-uglify": "^3.1.0",
     "grunt-eslint": "^21.0.0",
     "grunt-mkdir": "^1.0.0",
     "grunt-phpcbf": "^0.1.1",


### PR DESCRIPTION
Issue #39  

## Proposed changes

It's not always obvious that the Facebook/Twitter fields are from All in One SEO Pack. This PR makes a section header "All in One SEO Pack".

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [x] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- To produce this functionality, enable the Twitter/Facebook profile options in the Social Meta Module Settings. You should then see the fields in your profile, along with the new AIOSEOP section heading.
- It should show up if either Twitter _or_ Facebook _or_ both fields are configured to show up on the profile, but _not_ if neither is. (ie you shouldn't see the heading but not either field.)

## Further comments

For the code review- my first thought was to hook into some relevant action or filter, but _edit_user_profile_ was the closest. To use this, we'd have to migrate our current fields to the new custom ones, since the current fields use the _user_contactmethods_ filter. I'm sure we also could have used javascript to hijack the page as well.
What I did instead was to add another profile field called "aioseop_title" and just use CSS to hide the input field and increase the font-size so it only _looks_ like it's an H2.