### PR TITLE
Add filter hook for adding custom title formatting 

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1750,7 +1750,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function title_placeholder_helper( $title, $post, $type = 'post', $title_format = '', $category = '' ) {
-		
 		do_action( 'aioseop_before_title_placeholder_helper' );
 
 		if ( ! empty( $post ) ) {

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -868,9 +868,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		/**
 		 * Runs before we start applying the formatting for the snippet preview title.
-         *
-         * @since 3.0
-         *
+		 *
+		 * @since 3.0
+		 *
 		 */
 		do_action( 'aioseop_before_get_title_format' );
 

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -846,9 +846,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	}
 
 	/**
-	 * Get Title Format
+	 * Get Title Format for snippet preview.
 	 *
-	 * Get the title formatted according to AIOSEOP %shortcodes%.
+	 * Get the title formatted according to AIOSEOP %shortcodes% specifically for the snippet preview..
 	 *
 	 * @since 2.4.9
 	 *
@@ -866,6 +866,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		$w            = $info['w'];
 		$p            = $info['p'];
 
+		/**
+		 * Runs before we start applying the formatting for the snippet preview title.
+         *
+         * @since 3.0
+         *
+		 */
 		do_action( 'aioseop_before_get_title_format' );
 
 		if ( false !== strpos( $title_format, '%site_title%', 0 ) ) {
@@ -949,10 +955,24 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$title_format = str_replace( '%taxonomy_description%', $description, $title_format );
 		}
 
+		/**
+		 * Filters document title after applying the formatting.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $title_format Document title to be filtered.
+		 *
+		 */
 		$title_format = apply_filters( 'aioseop_title_format', $title_format, 10, 1 );
 
 		$title_format    = preg_replace( '/%([^%]*?)%/', '', $title_format );
 
+		/**
+		 * Runs after applying the formatting for the snippet preview title.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_after_format_title' );
 
 		return $title_format;
@@ -1739,7 +1759,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	}
 
 	/**
-	 * Replace title templates inside % symbol.
+	 * Replace doc title templates inside % symbol on the frontend.
 	 *
 	 * @param $title
 	 * @param $post
@@ -1750,6 +1770,13 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function title_placeholder_helper( $title, $post, $type = 'post', $title_format = '', $category = '' ) {
+
+		/**
+		 * Runs before applying the formatting for the doc title on the frontend.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_before_title_placeholder_helper' );
 
 		if ( ! empty( $post ) ) {
@@ -1821,8 +1848,22 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$new_title = str_replace( '%post_month%', get_the_date( 'F' ), $new_title );
 		}
 
+		/**
+		 * Filters document title after applying the formatting.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $new_title Document title to be filtered.
+		 *
+		 */
 		$new_title = apply_filters( 'aioseop_title_format', $new_title, 10, 1 );
 
+		/**
+		 * Runs after applying the formatting for the doc title on the frontend.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_after_title_placeholder_helper' );
 
 		$title = trim( $new_title );
@@ -2080,6 +2121,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function apply_tax_title_format( $category_name, $category_description, $tax = '' ) {
 
+		/**
+		 * Runs before applying the formatting for the taxonomy title.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_before_tax_title_format' );
 
 		if ( empty( $tax ) ) {
@@ -2112,10 +2159,24 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$title = str_replace( '%current_year%', date( 'Y' ), $title );
 		}
 
+		/**
+		 * Filters document title after applying the formatting.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $title Document title to be filtered.
+		 *
+		 */
 		$title = apply_filters( 'aioseop_title_format', $title, 10, 1 );
 
 		$title = wp_strip_all_tags( $title );
 
+		/**
+		 * Runs after applying the formatting for the taxonomy title.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_after_tax_title_format' );
 
 		return $this->paged_title( $title );

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1750,8 +1750,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function title_placeholder_helper( $title, $post, $type = 'post', $title_format = '', $category = '' ) {
-
-	    do_action ( 'aioseop_before_title_placeholder_helper' );
+		
+		do_action( 'aioseop_before_title_placeholder_helper' );
 
 		if ( ! empty( $post ) ) {
 			$authordata = get_userdata( $post->post_author );
@@ -1824,7 +1824,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		$new_title = apply_filters( 'aioseop_title_format', $new_title, 10, 1 );
 
-		do_action ( 'aioseop_after_title_placeholder_helper' );
+		do_action( 'aioseop_after_title_placeholder_helper' );
 
 		$title = trim( $new_title );
 
@@ -2081,7 +2081,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function apply_tax_title_format( $category_name, $category_description, $tax = '' ) {
 
-		do_action( 'aioseop_before_tax_title_format');
+		do_action( 'aioseop_before_tax_title_format' );
 
 		if ( empty( $tax ) ) {
 			$tax = get_query_var( 'taxonomy' );
@@ -2117,7 +2117,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		$title = wp_strip_all_tags( $title );
 
-		do_action( 'aioseop_after_tax_title_format');
+		do_action( 'aioseop_after_tax_title_format' );
 
 		return $this->paged_title( $title );
 	}
@@ -3866,7 +3866,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function apply_description_format( $description, $post = null ) {
 
-	    do_action( 'aioseop_before_apply_description_format' );
+		do_action( 'aioseop_before_apply_description_format' );
 
 		global $aioseop_options;
 		$description_format = $aioseop_options['aiosp_description_format'];

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -866,6 +866,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		$w            = $info['w'];
 		$p            = $info['p'];
 
+		do_action( 'aioseop_before_get_title_format' );
+
 		if ( false !== strpos( $title_format, '%site_title%', 0 ) ) {
 			$title_format = str_replace( '%site_title%', get_bloginfo( 'name' ), $title_format );
 		}
@@ -947,7 +949,11 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$title_format = str_replace( '%taxonomy_description%', $description, $title_format );
 		}
 
+		$title_format = apply_filters( 'aioseop_title_format', $title_format, 10, 1 );
+
 		$title_format    = preg_replace( '/%([^%]*?)%/', '', $title_format );
+
+		do_action( 'aioseop_after_format_title' );
 
 		return $title_format;
 	}
@@ -1744,6 +1750,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function title_placeholder_helper( $title, $post, $type = 'post', $title_format = '', $category = '' ) {
+
+	    do_action ( 'aioseop_before_title_placeholder_helper' );
+
 		if ( ! empty( $post ) ) {
 			$authordata = get_userdata( $post->post_author );
 		} else {
@@ -1812,6 +1821,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( false !== strpos( $new_title, '%post_month%', 0 ) ) {
 			$new_title = str_replace( '%post_month%', get_the_date( 'F' ), $new_title );
 		}
+
+		$new_title = apply_filters( 'aioseop_title_format', $new_title, 10, 1 );
+
+		do_action ( 'aioseop_after_title_placeholder_helper' );
 
 		$title = trim( $new_title );
 
@@ -1989,6 +2002,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function get_tax_title( $tax = '' ) {
+
 		if ( AIOSEOPPRO ) {
 			if ( empty( $this->meta_opts ) ) {
 				$this->meta_opts = $this->get_current_options( array(), 'aiosp' );
@@ -2066,6 +2080,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return string
 	 */
 	function apply_tax_title_format( $category_name, $category_description, $tax = '' ) {
+
+		do_action( 'aioseop_before_tax_title_format');
+
 		if ( empty( $tax ) ) {
 			$tax = get_query_var( 'taxonomy' );
 		}
@@ -2095,7 +2112,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( false !== strpos( $title, '%current_year%', 0 ) ) {
 			$title = str_replace( '%current_year%', date( 'Y' ), $title );
 		}
+
+		$title = apply_filters( 'aioseop_title_format', $title, 10, 1 );
+
 		$title = wp_strip_all_tags( $title );
+
+		do_action( 'aioseop_after_tax_title_format');
 
 		return $this->paged_title( $title );
 	}
@@ -3843,6 +3865,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return mixed
 	 */
 	function apply_description_format( $description, $post = null ) {
+
+	    do_action( 'aioseop_before_apply_description_format' );
+
 		global $aioseop_options;
 		$description_format = $aioseop_options['aiosp_description_format'];
 		if ( ! isset( $description_format ) || empty( $description_format ) ) {
@@ -3889,6 +3914,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		* if ($aioseop_options['aiosp_can']) $description = $this->make_unique_att_desc($description);
 		*/
 		$description = $this->apply_cf_fields( $description );
+
+		do_action( 'aioseop_after_apply_description_format' );
+
 		return $description;
 	}
 

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3926,6 +3926,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function apply_description_format( $description, $post = null ) {
 
+		/**
+		 * Runs before applying the formatting for the meta description.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_before_apply_description_format' );
 
 		global $aioseop_options;
@@ -3975,6 +3981,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		*/
 		$description = $this->apply_cf_fields( $description );
 
+		/**
+		 * Runs after applying the formatting for the meta description.
+		 *
+		 * @since 3.0
+		 *
+		 */
 		do_action( 'aioseop_after_apply_description_format' );
 
 		return $description;


### PR DESCRIPTION
Issue #942

## Proposed changes

Users and developers of other plugins have requested the ability to programmatically add their own title template tags.
I've also added some action hooks at the beginning and end of each relevant function.

## Types of changes

What types of changes does your code introduce?

- Adds new API hooks
- Improves existing functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [x] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate). #2447
- [x] I have added necessary documentation, or have created an issue for docs (if appropriate). #2446

## Testing instructions
- You'll want to peak at the code for a general overview of what's happening.
- You can find examples here: https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/2446#issue-444640702
- Make sure that all titles are as expected with and without the use of this filter. 
- I'm pretty sure this only applies to post (type) titles, and probably the homepage as well. It likely doesn't work for taxonomy titles.

## Further comments

Tester, code reviewer, etc... feel free to suggest a better filter name if you have one. 