### PR TITLE
match translation request language 

### DIFF
--- a/admin/display/general-metaboxes.php
+++ b/admin/display/general-metaboxes.php
@@ -81,7 +81,6 @@ class aiosp_metaboxes {
 						?>
 						<div class="aioseop_translations"><strong>
 								<?php
-
 								if ( $aiosp_trans->percent_translated < 100 ) {
 									if ( ! empty( $aiosp_trans->native_name ) ) {
 										$maybe_native_name = $aiosp_trans->native_name;

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -80,9 +80,9 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 
 			$current_locale = $this->current_locale;
 
-			if ( strpos( $current_locale, '_formal') ) {
+			if ( strpos( $current_locale, '_formal' ) ) {
 				$formal = $this->formal = 'formal';
-				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale);
+				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale );
 			} else {
 				$short_locale = $current_locale;
 				$formal = $this->formal = 'default';

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -81,11 +81,13 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 			$current_locale = $this->current_locale;
 
 			if ( strpos( $current_locale, '_formal' ) ) {
-				$formal = $this->formal = 'formal';
+				$this->formal = 'formal';
+				$formal = 'formal';
 				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale );
 			} else {
 				$short_locale = $current_locale;
-				$formal = $this->formal = 'default';
+				$this->formal = 'default';
+				$formal = 'default';
 			}
 
 			// Some locales are missing the locale code (wp_locale) so we need to check for that.

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -23,15 +23,10 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 		 * @var string $wplocale Information for a particular locale (in loop)
 		 */
 		public $wplocale = '';
-
 		public $translated_count = 0;
-
 		public $translation_url = 'https://translate.wordpress.org/projects/wp-plugins/all-in-one-seo-pack';
-
 		public $slug = '';
-
 		public $percent_translated = '';
-
 		public $native_name = '';
 
 		/**
@@ -66,7 +61,6 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 			if ( is_wp_error( $response ) ) {
 				return false;
 			}
-
 			return $response['body'];
 		}
 
@@ -75,38 +69,62 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 		 *
 		 * @since 2.3.5
 		 *
-		 * @param $locales
+		 * @param array $locales All locale info for AIOSEOP from translate.wordpress.org.
+		 * @var array $locale Individual locale info for AIOSEOP from translate.wordpress.org.
+		 * @var string $wp_locale Locale name from translate.wordpress.org (does not include formal designation).
+		 * @var string $formal Indication of whether currently active locale is formal.
+		 * @var string $slug Indication of whether locale from translate.wordpress.org is formal.
+		 * @var string $current_locale Currently active locale.
 		 */
 		private function set_current_locale_data( $locales ) {
+
+			$current_locale = $this->current_locale;
+
+
+			if ( strpos( $current_locale, '_formal') ){
+				$formal = $this->formal = 'formal';
+				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale);
+			}else{
+				$short_locale = $current_locale;
+				$formal = $this->formal = 'default';
+			}
+
 
 			// Some locales are missing the locale code (wp_locale) so we need to check for that.
 			foreach ( $locales as $locale ) {
 
-				$wplocale = '';
+				$slug = $locale->slug;
 
+				$wplocale = '';
 				if ( isset( $locale->wp_locale ) ) {
 					$wplocale = $locale->wp_locale;
 				}
 
-				if ( $wplocale === $this->current_locale ) {
-
-					$name               = '';
-					$percent_translated = '';
-
-					if ( isset( $locale->name ) ) {
-						$name = $locale->name;
-					}
-
-					if ( isset( $locale->percent_translated ) ) {
-						$percent_translated = $locale->percent_translated;
-					}
-
-					$this->name               = $name;
-					$this->wplocale           = $wplocale;
-					$this->percent_translated = $percent_translated;
-					$this->slug               = $locale->locale;
-
+				if ( $short_locale !== $wplocale ){
+					continue;
 				}
+
+				if( $formal !== $slug ){
+					continue;
+				}
+
+				$name               = '';
+				$percent_translated = '';
+
+				if ( isset( $locale->name ) ) {
+					$name = $locale->name;
+				}
+
+				if ( isset( $locale->percent_translated ) ) {
+					$percent_translated = $locale->percent_translated;
+				}
+
+				$this->name               = $name;
+				$this->wplocale           = $wplocale;
+				$this->percent_translated = $percent_translated;
+				$this->slug               = $locale->locale;
+
+
 			}
 
 		}
@@ -188,7 +206,6 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 			$this->set_current_locale_data( $locales );
 
 			$this->translated_count = $this->count_translated_languages( $locales );
-
 			$this->set_translation_url();
 
 			$this->set_native_language();

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -156,7 +156,7 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 
 			if ( null !== $this->wplocale ) {
 
-				$url = "https://translate.wordpress.org/projects/wp-plugins/all-in-one-seo-pack/dev/$this->slug/default";
+				$url = "https://translate.wordpress.org/projects/wp-plugins/all-in-one-seo-pack/dev/$this->slug/$this->formal/?filters%5Bstatus%5D=untranslated&sort%5Bby%5D=priority&sort%5Bhow%5D=desc";
 
 				$this->translation_url = $url;
 			}

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -80,15 +80,13 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 
 			$current_locale = $this->current_locale;
 
-
-			if ( strpos( $current_locale, '_formal') ){
+			if ( strpos( $current_locale, '_formal') ) {
 				$formal = $this->formal = 'formal';
 				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale);
-			}else{
+			} else {
 				$short_locale = $current_locale;
 				$formal = $this->formal = 'default';
 			}
-
 
 			// Some locales are missing the locale code (wp_locale) so we need to check for that.
 			foreach ( $locales as $locale ) {
@@ -100,11 +98,11 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 					$wplocale = $locale->wp_locale;
 				}
 
-				if ( $short_locale !== $wplocale ){
+				if ( $short_locale !== $wplocale ) {
 					continue;
 				}
 
-				if( $formal !== $slug ){
+				if ( $formal !== $slug ) {
 					continue;
 				}
 
@@ -123,8 +121,6 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 				$this->wplocale           = $wplocale;
 				$this->percent_translated = $percent_translated;
 				$this->slug               = $locale->locale;
-
-
 			}
 
 		}

--- a/inc/translations.php
+++ b/inc/translations.php
@@ -70,7 +70,7 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 		 * @since 2.3.5
 		 *
 		 * @param array $locales All locale info for AIOSEOP from translate.wordpress.org.
-		 * @var array $locale Individual locale info for AIOSEOP from translate.wordpress.org.
+		 * @var object $locale Individual locale info for AIOSEOP from translate.wordpress.org.
 		 * @var string $wp_locale Locale name from translate.wordpress.org (does not include formal designation).
 		 * @var string $formal Indication of whether currently active locale is formal.
 		 * @var string $slug Indication of whether locale from translate.wordpress.org is formal.
@@ -82,12 +82,12 @@ if ( ! class_exists( 'AIOSEOP_Translations' ) ) :
 
 			if ( strpos( $current_locale, '_formal' ) ) {
 				$this->formal = 'formal';
-				$formal = 'formal';
+				$formal       = 'formal';
 				$short_locale = $this->short_locale = str_replace( '_formal', '', $current_locale );
 			} else {
 				$short_locale = $current_locale;
 				$this->formal = 'default';
-				$formal = 'default';
+				$formal       = 'default';
 			}
 
 			// Some locales are missing the locale code (wp_locale) so we need to check for that.


### PR DESCRIPTION
Issue #2444  #2455

## Proposed changes

We reach out to translate.wordpress.org and get the info for translated locales, such as the percent translated. Due to issues with the way WordPress handles naming the locales, our code wasn't able to distinguish between formal and informal versions of the same language, resulting in incorrect information displaying. 

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions
- Verify the existing behavior. Check out German, German Formal, and others, and make sure the percentage shown is correct (100% locales should not show up at all).
- I've changed a string so that German won't be 100% anymore for testing purposes. Once this has been tested and code reviewed, we need to change it back.

## Further comments

Here are German, German (formal), and French. Note the translation percentages for each: 99%, 82%, and 95%, respectively.
<img width="962" alt="Screen Shot 2019-05-16 at 3 09 02 PM" src="https://user-images.githubusercontent.com/17364998/57880561-0f59ab00-77ed-11e9-9b22-40443df5487f.png">
<img width="951" alt="Screen Shot 2019-05-16 at 3 09 18 PM" src="https://user-images.githubusercontent.com/17364998/57880586-1a144000-77ed-11e9-858f-bef672710d90.png">
<img width="943" alt="Screen Shot 2019-05-16 at 3 10 54 PM" src="https://user-images.githubusercontent.com/17364998/57880587-1a144000-77ed-11e9-815f-8893717b8056.png">

Here is each loaded into the site in the same order. Notice that for German, it shows the info for German (formal), and for German (informal), it doesn't show anything. French is included as a control.
 
<img width="491" alt="Screen Shot 2019-05-16 at 3 09 43 PM" src="https://user-images.githubusercontent.com/17364998/57880682-5e9fdb80-77ed-11e9-98ed-32dfe6f3ae6e.png">
<img width="505" alt="Screen Shot 2019-05-16 at 3 08 47 PM" src="https://user-images.githubusercontent.com/17364998/57880698-665f8000-77ed-11e9-864c-c0f690659b32.png">
<img width="517" alt="Screen Shot 2019-05-16 at 3 10 49 PM" src="https://user-images.githubusercontent.com/17364998/57880702-69f30700-77ed-11e9-8c25-73e2ff50c36f.png">
