### PR TITLE
remove space in translated string #2452

### DIFF
--- a/inc/commonstrings.php
+++ b/inc/commonstrings.php
@@ -29,7 +29,7 @@ class AIOSP_Common_Strings {
 		__( 'Purchase one now', 'all-in-one-seo-pack' );
 		__( 'License Key is not set yet or invalid. ', 'all-in-one-seo-pack' );
 		/* translators: Please mind the space at the beginning of the string. */
-		__( ' Need a license key?', 'all-in-one-seo-pack' );
+		__( 'Need a license key?', 'all-in-one-seo-pack' );
 		__( 'Notice: ', 'all-in-one-seo-pack' );
 		__( 'Manage Licenses', 'all-in-one-seo-pack' );
 


### PR DESCRIPTION
Issue #2452

## Proposed changes

We have a string with a blank space in the beginning, which makes things challenging for translators who may not notice. This PR changes the translatable string in this repo. The string in the code itself is changed in https://github.com/semperfiwebdesign/aioseop-pro/pull/489

## Types of changes

What types of changes does your code introduce?

- Improves existing code

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Make sure the string shows up the way it should.

## Further comments

For code review, make sure the string is still going to be translatable and is where it should be.