### PR TITLE
Add aioseop_pre_tax_types_setting filter hook

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2898,6 +2898,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 		}
 
+		$tax_types = apply_filters( 'aioseop_pre_tax_types_setting', $tax_types );
+
 		$this->default_options['posttypecolumns']['initial_options'] = $post_types;
 		$this->default_options['cpostactive']['initial_options']     = $all_post_types;
 		$this->default_options['cpostnoindex']['initial_options']    = $post_types;
@@ -2936,8 +2938,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( empty( $tax_types ) ) {
 			unset( $this->default_options['tax_noindex'] );
 		}
-
-		$tax_types = apply_filters( 'aioseop_pre_tax_types_setting', $tax_types );
 
 		if ( AIOSEOPPRO ) {
 			foreach ( $tax_types as $p => $pt ) {

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2937,6 +2937,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			unset( $this->default_options['tax_noindex'] );
 		}
 
+		$tax_types = apply_filters( 'aioseop_pre_tax_types_setting', $tax_types );
+
 		if ( AIOSEOPPRO ) {
 			foreach ( $tax_types as $p => $pt ) {
 				$field = $p . '_tax_title_format';

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -2898,6 +2898,13 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 		}
 
+		/**
+		 * Allows users to filter the taxonomies that are shown in the General Settings menu.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array $tax_types All registered taxonomies.
+		 */
 		$tax_types = apply_filters( 'aioseop_pre_tax_types_setting', $tax_types );
 
 		$this->default_options['posttypecolumns']['initial_options'] = $post_types;


### PR DESCRIPTION
Issue 490 in Pro repo - https://github.com/semperfiwebdesign/aioseop-pro/issues/490

## Proposed changes

Adds a filter hook to filter the taxonomies that are displayed in the General Settings menu.

## Types of changes

- Adds new API hooks

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

@wpsmort I've already added documentation here with an example - https://semperplugins.com/wp-admin/post.php?post=4754&action=edit&lang=en.

Install a plugin which adds a custom taxonomy (e.g. Product Categories in WooCommerce) and then try to remove it through the filter hook.

Please also review the documentation - https://github.com/semperfiwebdesign/aioseop-pro/issues/491

## Further comments

None.
