### PR TITLE
Fix error invalid arg supplied for foreach in sitemap class

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -933,11 +933,14 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			$excl_terms = array();
-			foreach ( $options[ $this->prefix . 'excl_terms' ] as $k1_taxonomy => $v1_tax_terms ) {
-				foreach ( $v1_tax_terms['terms'] as $v2_term ) {
-					$excl_terms[] = $k1_taxonomy . '-' . $v2_term;
+			if ( isset( $options[ $this->prefix . 'excl_terms' ] ) && is_array( $options[ $this->prefix . 'excl_terms' ] ) ) {
+				foreach ( $options[ $this->prefix . 'excl_terms' ] as $k1_taxonomy => $v1_tax_terms ) {
+					foreach ( $v1_tax_terms['terms'] as $v2_term ) {
+						$excl_terms[] = $k1_taxonomy . '-' . $v2_term;
+					}
 				}
 			}
+
 			$options[ $this->prefix . 'excl_terms' ] = $excl_terms;
 
 			return $options;


### PR DESCRIPTION
Issue #2404

## Proposed changes

Fixes a php error warning with an invalid value for a foreach operator.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

1) Do a fresh install/activation of AIOSEOP.
2) Activate Sitemap module.
3) Go to Sitemap.
4) Error should be displayed ( if `WP_DEBUG` & `WP_DEBUG_DISPLAY` is true)

