### PR TITLE
Fix empty items for excl terms to select in sitemap settings

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -701,12 +701,16 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$taxonomies_active = $this->options['aiosp_sitemap_taxonomies'];
 			} elseif ( ! empty( $this->options['aiosp_sitemap_taxonomies'] ) ) {
 				$taxonomies_active = array( $this->options['aiosp_sitemap_taxonomies'] );
+			} else {
+				$taxonomies_active = get_taxonomies();
 			}
 
 			$args_taxonomy_key = array_search( 'all', $taxonomies_active, true );
 			if ( false !== $args_taxonomy_key ) {
 				// Remove 'all' as an invalid post_type. Use registered post_types selected instead.
 				unset( $taxonomies_active[ $args_taxonomy_key ] );
+				// Adds all the taxonomies regardless if other taxonomies are selected; ensures all taxonomies are added.
+				$taxonomies_active = array_merge( $taxonomies_active, get_taxonomies() );
 			}
 
 			$excl_terms_init_opts = array();

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -701,8 +701,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$taxonomies_active = $this->options['aiosp_sitemap_taxonomies'];
 			} elseif ( ! empty( $this->options['aiosp_sitemap_taxonomies'] ) ) {
 				$taxonomies_active = array( $this->options['aiosp_sitemap_taxonomies'] );
-			} else {
-				$taxonomies_active = get_taxonomies();
 			}
 
 			$args_taxonomy_key = array_search( 'all', $taxonomies_active, true );


### PR DESCRIPTION
Issue #2468

## Proposed changes

Fixes an issue previously discussed with "Fix exclude terms from custom taxonomies" #2379

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

1) Do a fresh install/activation of AIOSEOP. (use phpMyAdmin to delete aioseop_options from SQL database)
2) Go to feature manager and activate Sitemap
3) Go to Sitemap Settings > Exclude Terms
4) Selecting or typing in element will have no items to select. Expected behavior Terms should be loaded, even on a fresh install.


