### PR TITLE
remove extra filter hook arguments

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -963,7 +963,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		 * @param string $title_format Document title to be filtered.
 		 *
 		 */
-		$title_format = apply_filters( 'aioseop_title_format', $title_format, 10, 1 );
+		$title_format = apply_filters( 'aioseop_title_format', $title_format );
 
 		$title_format    = preg_replace( '/%([^%]*?)%/', '', $title_format );
 
@@ -1856,7 +1856,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		 * @param string $new_title Document title to be filtered.
 		 *
 		 */
-		$new_title = apply_filters( 'aioseop_title_format', $new_title, 10, 1 );
+		$new_title = apply_filters( 'aioseop_title_format', $new_title );
 
 		/**
 		 * Runs after applying the formatting for the doc title on the frontend.
@@ -2167,7 +2167,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		 * @param string $title Document title to be filtered.
 		 *
 		 */
-		$title = apply_filters( 'aioseop_title_format', $title, 10, 1 );
+		$title = apply_filters( 'aioseop_title_format', $title );
 
 		$title = wp_strip_all_tags( $title );
 


### PR DESCRIPTION
Issue #2480 

## Proposed changes


In #2445 we added some new filter hooks. I inadvertently added some arguments that shouldn't be there. 

## Types of changes

What types of changes does your code introduce?

- Removing old code/functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
- There's not much to really test here other than that the filters still work. 

## Further comments

It worked before, and this shouldn't break anything. We're just removing two arguments that shouldn't have been there.