### PR TITLE
extract newline out of translatable string

### DIFF
--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1215,7 +1215,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 */
 		function save_file( $filename, $contents ) {
 			$failed_str   = sprintf( __( 'Failed to write file %s!', 'all-in-one-seo-pack' ) . "\n", $filename );
-			$readonly_str = sprintf( __( "File %s isn't writable!", 'all-in-one-seo-pack' ) . "\n", $filename );
+			$readonly_str = sprintf( __( 'File %s isn\'t writable!', 'all-in-one-seo-pack' ) . "\n", $filename );
 			$wpfs         = $this->get_filesystem_object();
 			if ( is_object( $wpfs ) ) {
 				$file_exists = $wpfs->exists( $filename );
@@ -1250,7 +1250,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 						return true;
 					}
 				} else {
-					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
+					$this->output_error( sprintf( __( 'File %s doesn\'t exist!', 'all-in-one-seo-pack' ) . "\n", $filename ) );
 				}
 			}
 
@@ -1278,7 +1278,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 					}
 				} else {
 					if ( ! $file_exists ) {
-						$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
+						$this->output_error( sprintf( __( 'File %s doesn\'t exist!'", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} elseif ( $newfile_exists ) {
 						$this->output_error( sprintf( __( 'File %s already exists!', 'all-in-one-seo-pack' ) . "\n", $newname ) );
 					}

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1214,8 +1214,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 * @return bool
 		 */
 		function save_file( $filename, $contents ) {
-			$failed_str   = sprintf( __( "Failed to write file %s!", 'all-in-one-seo-pack' . "\n" ), $filename );
-			$readonly_str = sprintf( __( "File %s isn't writable!", 'all-in-one-seo-pack' . "\n" ), $filename );
+			$failed_str   = sprintf( __( "Failed to write file %s!", 'all-in-one-seo-pack' ) . "\n", $filename );
+			$readonly_str = sprintf( __( "File %s isn't writable!", 'all-in-one-seo-pack' ) . "\n", $filename );
 			$wpfs         = $this->get_filesystem_object();
 			if ( is_object( $wpfs ) ) {
 				$file_exists = $wpfs->exists( $filename );
@@ -1245,12 +1245,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			if ( is_object( $wpfs ) ) {
 				if ( $wpfs->exists( $filename ) ) {
 					if ( $wpfs->delete( $filename ) === false ) {
-						$this->output_error( sprintf( __( "Failed to delete file %s!", 'all-in-one-seo-pack' ), $filename . "\n" ) );
+						$this->output_error( sprintf( __( "Failed to delete file %s!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} else {
 						return true;
 					}
 				} else {
-					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ), $filename . "\n" ) );
+					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n" , $filename ) );
 				}
 			}
 
@@ -1272,15 +1272,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 				$newfile_exists = $wpfs->exists( $newname );
 				if ( $file_exists && ! $newfile_exists ) {
 					if ( $wpfs->move( $filename, $newname ) === false ) {
-						$this->output_error( sprintf( __( "Failed to rename file %s!", 'all-in-one-seo-pack' . "\n" ), $filename ) );
+						$this->output_error( sprintf( __( "Failed to rename file %s!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} else {
 						return true;
 					}
 				} else {
 					if ( ! $file_exists ) {
-						$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' . "\n" ), $filename ) );
+						$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} elseif ( $newfile_exists ) {
-						$this->output_error( sprintf( __( "File %s already exists!", 'all-in-one-seo-pack' . "\n" ), $newname ) );
+						$this->output_error( sprintf( __( "File %s already exists!", 'all-in-one-seo-pack' ) . "\n", $newname ) );
 					}
 				}
 			}

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1214,7 +1214,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 * @return bool
 		 */
 		function save_file( $filename, $contents ) {
-			$failed_str   = sprintf( __( "Failed to write file %s!", 'all-in-one-seo-pack' ) . "\n", $filename );
+			$failed_str   = sprintf( __( 'Failed to write file %s!', 'all-in-one-seo-pack' ) . "\n", $filename );
 			$readonly_str = sprintf( __( "File %s isn't writable!", 'all-in-one-seo-pack' ) . "\n", $filename );
 			$wpfs         = $this->get_filesystem_object();
 			if ( is_object( $wpfs ) ) {
@@ -1245,12 +1245,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			if ( is_object( $wpfs ) ) {
 				if ( $wpfs->exists( $filename ) ) {
 					if ( $wpfs->delete( $filename ) === false ) {
-						$this->output_error( sprintf( __( "Failed to delete file %s!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
+						$this->output_error( sprintf( __( 'Failed to delete file %s!', 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} else {
 						return true;
 					}
 				} else {
-					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n" , $filename ) );
+					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 				}
 			}
 
@@ -1272,7 +1272,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 				$newfile_exists = $wpfs->exists( $newname );
 				if ( $file_exists && ! $newfile_exists ) {
 					if ( $wpfs->move( $filename, $newname ) === false ) {
-						$this->output_error( sprintf( __( "Failed to rename file %s!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
+						$this->output_error( sprintf( __( 'Failed to rename file %s!', 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} else {
 						return true;
 					}
@@ -1280,7 +1280,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 					if ( ! $file_exists ) {
 						$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ) . "\n", $filename ) );
 					} elseif ( $newfile_exists ) {
-						$this->output_error( sprintf( __( "File %s already exists!", 'all-in-one-seo-pack' ) . "\n", $newname ) );
+						$this->output_error( sprintf( __( 'File %s already exists!', 'all-in-one-seo-pack' ) . "\n", $newname ) );
 					}
 				}
 			}

--- a/admin/aioseop_module_class.php
+++ b/admin/aioseop_module_class.php
@@ -1214,8 +1214,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 		 * @return bool
 		 */
 		function save_file( $filename, $contents ) {
-			$failed_str   = sprintf( __( "Failed to write file %s!\n", 'all-in-one-seo-pack' ), $filename );
-			$readonly_str = sprintf( __( "File %s isn't writable!\n", 'all-in-one-seo-pack' ), $filename );
+			$failed_str   = sprintf( __( "Failed to write file %s!", 'all-in-one-seo-pack' . "\n" ), $filename );
+			$readonly_str = sprintf( __( "File %s isn't writable!", 'all-in-one-seo-pack' . "\n" ), $filename );
 			$wpfs         = $this->get_filesystem_object();
 			if ( is_object( $wpfs ) ) {
 				$file_exists = $wpfs->exists( $filename );
@@ -1245,12 +1245,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 			if ( is_object( $wpfs ) ) {
 				if ( $wpfs->exists( $filename ) ) {
 					if ( $wpfs->delete( $filename ) === false ) {
-						$this->output_error( sprintf( __( "Failed to delete file %s!\n", 'all-in-one-seo-pack' ), $filename ) );
+						$this->output_error( sprintf( __( "Failed to delete file %s!", 'all-in-one-seo-pack' ), $filename . "\n" ) );
 					} else {
 						return true;
 					}
 				} else {
-					$this->output_error( sprintf( __( "File %s doesn't exist!\n", 'all-in-one-seo-pack' ), $filename ) );
+					$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' ), $filename . "\n" ) );
 				}
 			}
 
@@ -1272,15 +1272,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Module' ) ) {
 				$newfile_exists = $wpfs->exists( $newname );
 				if ( $file_exists && ! $newfile_exists ) {
 					if ( $wpfs->move( $filename, $newname ) === false ) {
-						$this->output_error( sprintf( __( "Failed to rename file %s!\n", 'all-in-one-seo-pack' ), $filename ) );
+						$this->output_error( sprintf( __( "Failed to rename file %s!", 'all-in-one-seo-pack' . "\n" ), $filename ) );
 					} else {
 						return true;
 					}
 				} else {
 					if ( ! $file_exists ) {
-						$this->output_error( sprintf( __( "File %s doesn't exist!\n", 'all-in-one-seo-pack' ), $filename ) );
+						$this->output_error( sprintf( __( "File %s doesn't exist!", 'all-in-one-seo-pack' . "\n" ), $filename ) );
 					} elseif ( $newfile_exists ) {
-						$this->output_error( sprintf( __( "File %s already exists!\n", 'all-in-one-seo-pack' ), $newname ) );
+						$this->output_error( sprintf( __( "File %s already exists!", 'all-in-one-seo-pack' . "\n" ), $newname ) );
 					}
 				}
 			}


### PR DESCRIPTION
Issue #2456 

## Proposed changes

We should remove \n from translatable strings so that it doesn't confuse translators who may remove them.

## Types of changes

What types of changes does your code introduce?

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Take a peak at the code to see what triggers the strings to show up, and make sure when they display the newline comes along with it as before.

## Further comments

This isn't necessarily every location in the entire plugin, but it was the strings we modified in this release (and a few others in the same file).