### PR TITLE
Move About Metabox DashIcons

### DIFF
--- a/css/aioseop-font-icons.css
+++ b/css/aioseop-font-icons.css
@@ -156,3 +156,43 @@ div.aioseop_tip_icon {
 div.aioseop_tip_icon:before {
 	content: '?';
 }
+
+/* ABOUT METABOX */
+
+.aiosp-di .dashicons {
+	margin: 1px;
+	line-height: 1;
+	width: 42px;
+	height: 36px;
+	color: #fff;
+	padding: 3px;
+	vertical-align: middle;
+}
+
+.aiosp-di .dashicons:before {
+	-webkit-font-smoothing: antialiased;
+	font-family: 'dashicons';
+	font-weight: 400;
+	font-size: 1.5em;
+	line-height: 38px;
+}
+
+.aiosp-di .dashicons.di-facebook {
+	margin: 0;
+	color: #3B5998;
+}
+
+.aiosp-di .dashicons.di-facebook:before {
+	content: '\f304';
+	font-size: 2.7em;
+}
+
+.aiosp-di .dashicons.di-twitter {
+	width: 36px;
+	background-color: #00aced;
+	border-radius: 2px;
+}
+
+.aiosp-di .dashicons.di-twitter:before {
+	content: '\f301';
+}

--- a/css/aiosp_admin.css
+++ b/css/aiosp_admin.css
@@ -36,40 +36,6 @@ li#wp-admin-bar-aioseop-pro-upgrade a.ab-item {
 	font-size: 110%;
 }
 
-/* Dashicons in sidebar */
-
-.aiosp-di .dashicons {
-	margin:1px;
-	line-height: 1;
-	width: 42px;
-	height:36px;
-	color:#fff;
-	padding:3px;
-	vertical-align:middle;
-}
-.aiosp-di .dashicons:before {
-	-webkit-font-smoothing:antialiased;
-	font:400 30px/1 dashicons;
-	line-height: 38px;
-}
-.aiosp-di .dashicons.di-facebook {
-	margin:0;
-}
-.aiosp-di .dashicons.di-facebook:before {
-	content:"\f304";
-	font-size:52px;
-}
-.aiosp-di .dashicons.di-twitter:before {
-	content:"\f301"
-}
-.aiosp-di .dashicons.di-facebook {
-	color: #3B5998;
-}
-.aiosp-di .dashicons.di-twitter {
-	width: 36px;
-	background-color:#00aced;
-	border-radius:2px;
-}
 .upgrade_menu_link {
 	font-weight: 900;
 	color: #d54e21;


### PR DESCRIPTION
Issue #1912

## Proposed changes

Moves the dashicons from the About Metabox into the font icons styles

## Types of changes


- Improves existing functionality
- Improves existing code

## Checklist


- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Activate and check general settings about metabox.
