### PR TITLE
 Move Tip Icon to font-icon.css

### DIFF
--- a/css/aioseop-font-icons.css
+++ b/css/aioseop-font-icons.css
@@ -136,3 +136,23 @@
 .aioseop-label-quickedit {
 	padding-left: 20px;
 }
+
+/* TIP ICON ( Robots ) */
+
+div.aioseop_tip_icon {
+	font-size: 14px;
+	border: 1px solid #888;
+	width: 1em;
+	text-align: center;
+	padding: 0 4px;
+	-webkit-border-radius: 12px;
+	-moz-border-radius: 12px;
+	-webkit-box-shadow: 1px 1px 1px #888;
+	-moz-box-shadow: 1px 1px 1px #888;
+	box-shadow: 1px 1px 1px #888;
+	border-radius: 12px;
+}
+
+div.aioseop_tip_icon:before {
+	content: '?';
+}

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -59,24 +59,6 @@
 	margin-left: 8px;
 }
 
-div.aioseop_tip_icon {
-	font-size: 14px;
-	border: 1px solid #888;
-	width: 1em;
-	text-align: center;
-	padding: 0 4px;
-	-webkit-border-radius: 12px;
-	-moz-border-radius: 12px;
-	-webkit-box-shadow: 1px 1px 1px #888;
-	-moz-box-shadow: 1px 1px 1px #888;
-	box-shadow: 1px 1px 1px #888;
-	border-radius: 12px;
-}
-
-div.aioseop_tip_icon:before {
-	content: '?';
-}
-
 .aioseop_help_text_link img {
 	width: 40px;
 	float: left;


### PR DESCRIPTION
Issue #1913

## Proposed changes

Moves font icon styles to the font-icons.css file.

## Types of changes

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
1. Activate, and check AIOSEOP settings.
2. Then check the icons

