### PR TITLE
Change AJAX accept & delete to Font-Icons

### DIFF
--- a/css/aioseop-font-icons.css
+++ b/css/aioseop-font-icons.css
@@ -82,3 +82,34 @@
 	content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAflBMVEUAAAAAn98AnuIAn+EAneAAnuAAnuAAn+QAn+QAneEAnuAAnuAAn+EAnuAAnuEAneAAn+cAneAAnuAAn98AnOIAnuEAneIAn+MAnuEAnuEAn+EAneIAneEAneEAnuEAn+MAneAAneEAnuMAnOIAn+cAneEBnuEAneAAnuMBnuEoGewkAAAAKXRSTlMAEE9/r7/fADCPzwBv718AIPDAAFCwYEAAoAAAn4CQAOAAPwAAcADQAFP96WQAAAMNSURBVHhelZcNc5swDIatBghpoCGEj9Jij2XLMv3/P7glkoNtZJo+d+0lhBOveSXZUjHgZZOkGf4nS5PNC5wiKPFqvnvFgNddvpVQy0tQZCiSFfCEAtiUGKXcwFcB3kpcpXx791HetypFn2NdH9EnrX67KPdL46g/tl3PeqHvWidM2fxyUM7n3fzgof8R0A9zjN3PGTV/HB+6teg66EeIUQqQIGOiSQMGmeRgUQfGPn/Ktyv0k9UQKrCxWzitAq3V6dvYIDG8f8mAROO6ULF/3ecTaHazcvIgjTw/PxfFeVFErCHd31C3fx2v39cKGy6qLKyA1tGr/v8BLWDyb3OLqiw+XGCiq8DFxIvypMKIHqMXvaeLmmyEkn1xSTCAjWcMS7gruFD+eo/QuEC7AYCy+nJXkC1/r5A4Gq2NrQCvjMnL7OZCLggY3KoAI5jMEvKt2hohBYK3wiveuwx8i3qn/uvVf0O2Hh5MnLwOZMTrXgGt4OCi7RuyXNg1F1oDqEZIQh2K6oUALalSWqgiIwUIM4VVqZZvdlkE7QQFFLRVNS3l5NLZarMkgkx6ebWiNPqzSu9nEkM2KDZhjbykh+19KKri3+LkIxLhVlE/E4CaAjsd4AYo9zJkR9huGF7CtPYSX9FyXG4XFHe2UQIt9fIGa6NNJBErX2r35O0wp7KEbZYSNpVtMYngSpbZYoI1G9YClFzOp+vKS6jviLFJ+fWgDralfZO5peW2xX8LKB9NdTtxsQuc7/wV0OTv/YRyiUuIugCls7FwizffsXHgzcRurjEjYgH8zdVKyODZJUDGAuxZubNnt5BIgMQ7YNyowy2c0XfCqyNX6HzE2Ve8A28+nmDDHaJyD9sNChpkxvCYRxgkEjitAkl40AzPjxm7KdNnSAzLgaNFZhcVATtkBmliGaTJSJ6mBnnkMWgpx+XAMZZoMbGZqXEHm6Q4sxA4F4k7DEkjD1PVGJCmGFDLQ5elO+Iqx7B/q88A0FKI+DSlBLMuE4pMF3h6+DZXDLia6PAtA41u67uUqW51E02uf46zvXx+HY4YAAAAAElFTkSuQmCC);
 }
 
+/* QUICKEDIT - AJAX Edit */
+
+.aioseop-icon-qedit {
+	margin: 0 3px;
+	line-height: 2;
+	font-size: 14px;
+}
+
+.aioseop-icon-qedit-accept {
+	color: #9dd490;
+}
+
+.aioseop-icon-qedit-accept:hover {
+	color: #97eb84;
+}
+
+.aioseop-icon-qedit-accept:before {
+	content: '\70';
+}
+
+.aioseop-icon-qedit-delete {
+	color: #ed8881;
+}
+
+.aioseop-icon-qedit-delete:hover {
+	color: #ffad9e;
+}
+
+.aioseop-icon-qedit-delete:before {
+	content: '\71';
+}

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -214,11 +214,6 @@ if ( ! function_exists( 'aioseop_admin_head' ) ) {
 				position: absolute;
 			}
 
-			.aioseop_mpc_SEO_admin_options_edit img {
-				margin: 3px 2px;
-				opacity: 0.7;
-			}
-
 			.aioseop_mpc_admin_meta_options {
 				float: left;
 				display: block;

--- a/js/quickedit_functions.js
+++ b/js/quickedit_functions.js
@@ -49,10 +49,8 @@ function aioseop_ajax_edit_meta_form( post_id, meta, nonce ) {
 	var element = uform.html(); var input;
 	input = '<textarea id="aioseop_new_'+meta+'_' + post_id + '" style="font-size:13px;width:100%;float:left;position:relative;z-index:1;" rows=4 cols=32>'  + post_title + '</textarea>';
 	input += '<label style="float:left">';
-	input += '<a class="aioseop_mpc_SEO_admin_options_edit" href="javascript:void(0);" id="aioseop_'+meta+'_save_' + post_id + '" >';
-	input += '<img src="' + aioseopadmin.imgUrl+'accept.png" border="0" alt="" title="'+meta+'" /></a>';
-	input += '<a class="aioseop_mpc_SEO_admin_options_edit" href="javascript:void(0);" id="aioseop_'+meta+'_cancel_' + post_id + '" >';
-	input += '<img src="' + aioseopadmin.imgUrl+'delete.png" border="0" alt="" title="'+meta+'" /></a>';
+	input += '<a class="aioseop-icon-qedit aioseop-icon-qedit-accept" href="javascript:void(0);" id="aioseop_' + meta + '_save_' + post_id + '" title="Accept" >';
+	input += '<a class="aioseop-icon-qedit aioseop-icon-qedit-delete" href="javascript:void(0);" id="aioseop_' + meta + '_cancel_' + post_id + '" title="Decline" >';
 	input += '</label>';
 	uform.html( input );
 	uform.attr( "class", "aioseop_mpc_admin_meta_options aio_editing" );


### PR DESCRIPTION
Issue #1915

## Proposed changes

Changes the quick-edit buttons on the All Posts screen.

## Types of changes


- New feature (non-breaking change which adds functionality)
- Improves existing functionality
- Improves existing code

## Checklist


- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. Activate, and go to Posts > All Posts.
2. Under columns SEO Title/Description, click the edit button.
3. The drop down should show the new accept and cancel buttons.

![quickedit-after](https://user-images.githubusercontent.com/2794445/58363653-7b2abc00-7e5c-11e9-8fe6-0fbd9bd4c6f2.gif)

