### PR TITLE
Change cog_edit to Font-Icon

### DIFF
--- a/css/aioseop-font-icons.css
+++ b/css/aioseop-font-icons.css
@@ -113,3 +113,26 @@
 .aioseop-icon-qedit-delete:before {
 	content: '\71';
 }
+
+/* QUICKEDIT */
+
+.aioseop_edit_link {
+	display: inline-block;
+	position: absolute;
+}
+
+.aioseop-icon-cog-edit {
+	color: #72777c;
+}
+
+.aioseop-icon-cog-edit:hover {
+	color: #0073aa;
+}
+
+.aioseop-icon-cog-edit:before {
+	content: '\6e';
+}
+
+.aioseop-label-quickedit {
+	padding-left: 20px;
+}

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -203,17 +203,6 @@ if ( ! function_exists( 'aioseop_admin_head' ) ) {
 		wp_enqueue_script( 'aioseop_welcome_js', AIOSEOP_PLUGIN_URL . 'js/quickedit_functions.js', array( 'jquery' ), AIOSEOP_VERSION );
 		?>
 		<style>
-			.aioseop_edit_button {
-				margin: 0 0 0 5px;
-				opacity: 0.6;
-				width: 12px;
-			}
-
-			.aioseop_edit_link {
-				display: inline-block;
-				position: absolute;
-			}
-
 			.aioseop_mpc_admin_meta_options {
 				float: left;
 				display: block;
@@ -369,18 +358,22 @@ if ( ! function_exists( 'aioseop_ajax_save_meta' ) ) {
 			die();
 		}
 		if ( $result != '' ) :
-			$label = "<label id='aioseop_label_{$target}_{$post_id}'><span style='width: 20px;display: inline-block;'></span>" . $result . '</label>';
+			$label = "<label id='aioseop_label_{$target}_{$post_id}' class='aioseop-label-quickedit' for='{$target}editlink{$id}'>" . $result . '</label>';
 		else :
-			$label = "<label id='aioseop_label_{$target}_{$post_id}'></label><span style='width: 20px;display: inline-block;'></span><strong><i>" . __( 'No', 'all-in-one-seo-pack' ) . ' ' . $target . '</i></strong>';
+			$label = "<label id='aioseop_label_{$target}_{$post_id}' class='aioseop-label-quickedit' for='{$target}editlink{$id}'></label><strong><i>" . __( 'No', 'all-in-one-seo-pack' ) . ' ' . $target . '</i></strong>';
 		endif;
 		$nonce  = wp_create_nonce( "aioseop_meta_{$target}_{$post_id}" );
-		$output = '<a id="' . $target . 'editlink' . $post_id . '" class="aioseop_edit_link" href="javascript:void(0);"'
-				  . 'onclick=\'aioseop_ajax_edit_meta_form(' . $post_id . ', "' . $target . '", "' . $nonce . '");return false;\' title="' . __( 'Edit' ) . '">'
-				  . '<img class="aioseop_edit_button" id="aioseop_edit_id" src="' . AIOSEOP_PLUGIN_IMAGES_URL . '/cog_edit.png" /></a> ' . $label;
+		$output = '<a id="' . $target . 'editlink' . $post_id . '" '
+			. 'class="aioseop_edit_link aioseop-icon-cog-edit" '
+			. 'href="javascript:void(0);" '
+			. 'onclick=\'aioseop_ajax_edit_meta_form(' . $post_id . ', "' . $target . '", "' . $nonce . '");return false;\' '
+			. 'title="' . __( 'Edit' ) . '"></a>';
+		$output .= $label;
 		die(
-			"jQuery('div#aioseop_" . $target . '_' . $post_id . "').fadeOut('fast', function() { var my_label = " . json_encode( $output ) . ";
-			  jQuery('div#aioseop_" . $target . '_' . $post_id . "').html(my_label).fadeIn('fast');
-		});"
+			"jQuery('div#aioseop_" . $target . '_' . $post_id . "').fadeOut('fast', function() {
+				 var my_label = " . json_encode( $output ) . ";
+				 jQuery('div#aioseop_" . $target . '_' . $post_id . "').html(my_label).fadeIn('fast');
+			});"
 		);
 	}
 }
@@ -745,16 +738,17 @@ if ( ! function_exists( 'aioseop_mrt_pccolumn' ) ) {
 					<?php
 					$content = strip_tags( stripslashes( get_post_meta( $id, '_aioseop_' . $target, true ) ) );
 					if ( ! empty( $content ) ) :
-						$label = "<label id='aioseop_label_{$target}_{$id}'><span style='width: 20px;display: inline-block;'></span>" . $content . '</label>';
+						$label = "<label id='aioseop_label_{$target}_{$id}' class='aioseop-label-quickedit'>" . $content . '</label>';
 					else :
-						$label = "<label id='aioseop_label_{$target}_{$id}'></label><span style='width: 20px;display: inline-block;'></span><strong><i>" . __( 'No', 'all-in-one-seo-pack' ) . ' ' . $target . '</i></strong>';
+						$label = "<label id='aioseop_label_{$target}_{$id}' class='aioseop-label-quickedit'></label><strong><i>" . __( 'No', 'all-in-one-seo-pack' ) . ' ' . $target . '</i></strong>';
 					endif;
 					$nonce = wp_create_nonce( "aioseop_meta_{$target}_{$id}" );
-					echo '<a id="' . $target . 'editlink' . $id . '" class="aioseop_edit_link" href="javascript:void(0);" onclick=\'aioseop_ajax_edit_meta_form(' .
-						 $id . ', "' . $target . '", "' . $nonce . '");return false;\' title="' . __( 'Edit' ) . '">'
-						 . "<img class='aioseop_edit_button'
-											id='aioseop_edit_id'
-											src='" . AIOSEOP_PLUGIN_IMAGES_URL . "cog_edit.png' /></a> " . $label;
+					echo '<a id="' . $target . 'editlink' . $id . '" '
+						. 'class="aioseop_edit_link aioseop-icon-cog-edit" '
+						. 'href="javascript:void(0);" '
+						. 'onclick=\'aioseop_ajax_edit_meta_form(' . $id . ', "' . $target . '", "' . $nonce . '");return false;\' '
+						. 'title="' . __( 'Edit' ) . '"></a>';
+					echo $label;
 					?>
 				</div>
 			</div>


### PR DESCRIPTION
Issue #1916

## Proposed changes

Changes the cog_edit quick-edit button on the All Posts screen.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
1. Activate, and go to Posts > All Posts.
2. Under columns SEO Title/Description
3) The cog_edit button should display the revise font icon.

## Further comments

![quickedit-after](https://user-images.githubusercontent.com/2794445/58363653-7b2abc00-7e5c-11e9-8fe6-0fbd9bd4c6f2.gif)
