### PR TITLE
Update help text for Excluded Terms setting

### DIFF
--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -651,7 +651,7 @@ class AIOSEOP_Helper {
 			'aiosp_sitemap_addl_prio'       => __( 'The priority of the page.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_addl_freq'       => __( 'The frequency of the page.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_addl_mod'        => __( 'Last modified date of the page.', 'all-in-one-seo-pack' ),
-			'aiosp_sitemap_excl_terms' => __( 'Entries from these categories will be excluded from the sitemap.', 'all-in-one-seo-pack' ),
+			'aiosp_sitemap_excl_terms'      => __( 'Entries from these taxonomy terms will be excluded from the sitemap.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_excl_pages'      => __( 'Use page slugs or page IDs, seperated by commas, to exclude pages from the sitemap.', 'all-in-one-seo-pack' ),
 		);
 

--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -651,7 +651,7 @@ class AIOSEOP_Helper {
 			'aiosp_sitemap_addl_prio'       => __( 'The priority of the page.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_addl_freq'       => __( 'The frequency of the page.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_addl_mod'        => __( 'Last modified date of the page.', 'all-in-one-seo-pack' ),
-			'aiosp_sitemap_excl_terms'      => __( 'Entries from these taxonomy terms will be excluded from the sitemap.', 'all-in-one-seo-pack' ),
+			'aiosp_sitemap_excl_terms'      => __( 'Exclude any category, tag or custom taxonomy from the XML sitemap. Start typing the name of a category, tag or taxonomy term in the field and a dropdown will populate with the matching terms for you to select from.<br/><br/>This will also exclude any content belonging to the specified term.  For example, if you exclude the "Uncategorized" category then all posts in that category will also be excluded from the sitemap.', 'all-in-one-seo-pack' ),
 			'aiosp_sitemap_excl_pages'      => __( 'Use page slugs or page IDs, seperated by commas, to exclude pages from the sitemap.', 'all-in-one-seo-pack' ),
 		);
 


### PR DESCRIPTION
Issue #2498

## Proposed changes

Updates the help text for the new "Excluded Terms" setting since we're still using the old one from the "Excluded Categories" setting which we now removed.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Check the "Excluded Terms" setting in the XML Sitemap menu and make sure it looks good.

## Further comments

PR for "Excluded Terms" setting in Video Sitemap menu can be found here - https://github.com/semperfiwebdesign/aioseop-pro/pull/496
