### PR TITLE
Import SEO data from Rank Math

### DIFF
--- a/admin/meta_import.php
+++ b/admin/meta_import.php
@@ -518,7 +518,6 @@ function aiosp_seometa_import() {
 		'Rank Math'			=> array(
 			'Custom Doctitle'  => 'rank_math_title',
 			'META Description' => 'rank_math_description',
-			'META Keywords'    => 'rank_math_focus_keyword',
 			'Canonical URI'    => 'rank_math_canonical_url',
 		),
 		'SEOpressor'                 => array(

--- a/admin/meta_import.php
+++ b/admin/meta_import.php
@@ -515,7 +515,7 @@ function aiosp_seometa_import() {
 			'META Description' => 'description',
 			'META Keywords'    => 'keywords',
 		),
-		'Rank Math'			=> array(
+		'Rank Math'                    => array(
 			'Custom Doctitle'  => 'rank_math_title',
 			'META Description' => 'rank_math_description',
 			'Canonical URI'    => 'rank_math_canonical_url',

--- a/admin/meta_import.php
+++ b/admin/meta_import.php
@@ -515,6 +515,12 @@ function aiosp_seometa_import() {
 			'META Description' => 'description',
 			'META Keywords'    => 'keywords',
 		),
+		'Rank Math'			=> array(
+			'Custom Doctitle'  => 'rank_math_title',
+			'META Description' => 'rank_math_description',
+			'META Keywords'    => 'rank_math_focus_keyword',
+			'Canonical URI'    => 'rank_math_canonical_url',
+		),
 		'SEOpressor'                 => array(
 			'Custom Doctitle'  => '_seopressor_meta_title',
 			'META Description' => '_seopressor_meta_description',


### PR DESCRIPTION
Import SEO data from Rank Math - Issue #2185

## Proposed changes

Added import code for the Rank Math plugin to the SEO Data Import Tool

## Types of changes

- New feature: Added an additional option to the importable plugin drop down and tied meta-data elements from Rank Math to All In One SEO

## Checklist

- [X] I've selected the appropriate branch (ie x.y rather than master).
- [X] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1) Install, activate the "Rank Math" plug-in ( https://rankmath.com/ ) 
2) Install, activate the "All In One SEO Pack" plugin.
    a) Go to: All In One SEO > General Settings
        • Check: Canonical URLs
        • Check: Enable Custom Canonical URLs
3) Create or Edit a WordPress page
    a) Go to the "All In One SEO" settings section for the page
        • Make sure the Title,  Description, Keywords and Custom Canonical URL fields are blank
    b) Go to the "Rank Math SEO" settings section for the page
        • General Tab
            - Click: Edit Snippet
                -- Edit the SEO title for the page ( i.e. "Rank Math Test Tile" )
                    NOTE: Do not use the Rank Math place holders ( i.e. %title% etc. ).
                -- Edit the SEO description ( excerpt ) for the page ( i.e. "Rank Math Test Description" )
            - Enter into the "Focus Keyword" field a comma delimited list of test words ( i.e. Rank,Math,Test )
        • Advanced Tab
            - In the "Canonical URL" field enter a test URL ( i.e. "https://rank_math_import.com" )
4) Update the page
5) Go to: Tools > SEO Data Import
    a) In the "Import SEO data from" drop down select "Rank Math"
    b) Click: Convert
6) Return to the test page
    a) The "All In One SEO" settings section should now have the "Rank Math" data in the Title,  
        Description, Keywords and Custom Canonical URL fields