### PR TITLE
replace sitemap url in robotstxt option with filter hook 

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -624,7 +624,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			 *
 			 * Defaults to true. Return __return_false in order to not display the URL.
 			 *
-			 * Since 3.0
+			 * @since 3.0
 			 *
 			 * @param boolean Defaults to true.
 			 */

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -207,10 +207,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				'archive'     => array( 'name' => __( 'Include Date Archive Pages', 'all-in-one-seo-pack' ) ),
 				'author'      => array( 'name' => __( 'Include Author Pages', 'all-in-one-seo-pack' ) ),
 				'images'      => array( 'name' => __( 'Exclude Images', 'all-in-one-seo-pack' ) ),
-				'robots'      => array(
-					'name'    => __( 'Link From Virtual Robots.txt', 'all-in-one-seo-pack' ),
-					'default' => 'On',
-				),
 				'rewrite'     => array(
 					'name'    => __( 'Dynamically Generate Sitemap', 'all-in-one-seo-pack' ),
 					'default' => 'On',
@@ -623,7 +619,16 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$this->setup_rewrites();
 			}
 
-			if ( $this->option_isset( 'robots' ) ) {
+			/**
+			 * Filters whether to display the URL to the XML Sitemap on our virtual robots.txt file.
+			 *
+			 * Defaults to true. Return __return_false in order to not display the URL.
+			 *
+			 * Since 3.0
+			 *
+			 * @param boolean Defaults to true.
+			 */
+			if ( apply_filters( 'aioseop_robotstxt_sitemap_url', true ) ) {
 				add_action( 'do_robots', array( $this, 'do_robots' ), 100 );
 			}
 


### PR DESCRIPTION
Issue #535 

## Proposed changes

Removes option to include the XML Sitemap URL in our robots.txt file, but retains the functionality, which defaults to on. An API filter hook is added to disable the functionality.
Previous settings are not respected.

## Types of changes

What types of changes does your code introduce?

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Adds new API hooks
- Removing old code/functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [x] I have added necessary documentation, or have created an issue for docs (if appropriate). #2519

## Testing instructions
- Verify that the URL is inserted into the robots.txt.
- Verify that returning false on the new filter hook removes the URL.

