### PR TITLE
 Fix sitemap index 1000+ posts notice check

### DIFF
--- a/admin/class-aioseop-notices.php
+++ b/admin/class-aioseop-notices.php
@@ -467,7 +467,14 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 		 * @return bool
 		 */
 		public function reset_notice( $slug ) {
-			if ( empty( $slug ) || ! isset( $this->notices[ $slug ] ) ) {
+			if (
+					empty( $slug ) ||
+					(
+							! isset( $this->notices[ $slug ] ) &&
+							! get_user_meta( get_current_user_id(), 'aioseop_notice_display_time_' . $slug, true ) &&
+							! get_user_meta( get_current_user_id(), 'aioseop_notice_dismissed_' . $slug, true )
+					)
+			) {
 				return false;
 			}
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -440,7 +440,6 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 				$sitemap_urls = $post_counts + $num_terms;
 
-
 				if ( 1000 < $sitemap_urls ) {
 					$aioseop_notices->activate_notice( 'sitemap_max_warning' );
 				} else {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -402,6 +402,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 *
 		 * @todo Move admin notice functions. Possibly to where it is first saved & loaded (`load_sitemap_options`).
 		 *
+		 * @global AIOSEOP_Notices $aioseop_notices
+		 *
 		 * @since 2.4.1
 		 */
 		public function sitemap_notices() {
@@ -409,12 +411,19 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return;
 			}
 
+			global $aioseop_notices;
 			$options = $this->options;
 
 			if (
-				isset( $options[ "{$this->prefix}indexes" ] ) &&
-				'on ' !== $options[ "{$this->prefix}indexes" ] &&
-				1001 < $options[ "{$this->prefix}max_posts" ]
+					(
+							isset( $options[ "{$this->prefix}indexes" ] ) &&
+							'on' !== $options[ "{$this->prefix}indexes" ]
+					) ||
+					(
+							isset( $options[ "{$this->prefix}indexes" ] ) &&
+							'on' === $options[ "{$this->prefix}indexes" ] &&
+							1000 < $options[ "{$this->prefix}max_posts" ]
+					)
 			) {
 				$num_terms   = 0;
 				$post_counts = $this->get_total_post_count(
@@ -431,12 +440,14 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 				$sitemap_urls = $post_counts + $num_terms;
 
-				global $aioseop_notices;
-				if ( 1001 > $sitemap_urls ) {
-					$aioseop_notices->deactivate_notice( 'sitemap_max_warning' );
-				} else {
+
+				if ( 1000 < $sitemap_urls ) {
 					$aioseop_notices->activate_notice( 'sitemap_max_warning' );
+				} else {
+					$aioseop_notices->deactivate_notice( 'sitemap_max_warning' );
 				}
+			} else {
+				$aioseop_notices->deactivate_notice( 'sitemap_max_warning' );
 			}
 		}
 


### PR DESCRIPTION
Issue #2540

## Proposed changes

The notice that displays when sitemap pagination is greater than 1000 does not go away when pagination is set to less than 1000.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

![](https://user-images.githubusercontent.com/17548525/58672311-5cbd3880-8314-11e9-899a-771d0bdef6f2.png)

