### PR TITLE
Make Button Orange Again

### DIFF
--- a/admin/display/notices/wc-detected-notice.php
+++ b/admin/display/notices/wc-detected-notice.php
@@ -30,7 +30,7 @@ function aioseop_notice_pro_promo_woocommerce() {
 				'text'    => __( 'Upgrade', 'all-in-one-seo-pack' ),
 				'link'    => 'https://semperplugins.com/plugins/all-in-one-seo-pack-pro-version/?loc=woo',
 				'dismiss' => false,
-				'class'   => 'button-primary',
+				'class'   => 'button-primary button-orange',
 			),
 			array(
 				'time'    => 2592000, // 30 days.


### PR DESCRIPTION
Issue #2405

## Proposed changes

We made the button orange in #2405, but then in a merge error removed it. This PR makes it orange again.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Install WooCommerce
- Make sure the WooCommerce upgrade button is orange.

## Further comments
