### PR TITLE
Fix sitemap PHP errors with WP < 5.2

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -3380,7 +3380,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 						$timestamp      = mysql2date( 'U', $post->post_modified_gmt );
 						$pr_info['rss'] = array(
 							'title'       => $title,
-							'description' => get_the_excerpt( $post ),
+							'description' => get_post_field( 'post_excerpt', $post->ID ),
 							'pubDate'     => date( 'r', $timestamp ),
 							'timestamp  ' => $timestamp,
 							'post_type'   => $post->post_type,


### PR DESCRIPTION
Issue #2549

## Proposed changes

Fix a couple related PHP errors when using `get_post_excerpt()` on the sitemap when no global `$post` is being set.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. Have WP install that is below 5.2.
2. Go to sitemap settings, and enable indexes.
3. Go to frontend sitemap.
4. Click on any of the indexed post types, and an xml error will display.

```
This page contains the following errors:
error on line 2 at column 1: Extra content at the end of the document
Below is a rendering of the page up to the first error.
```
