### PR TITLE
Fix sitemap not excluding posts properly with max_posts setting

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4369,7 +4369,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				),
 			);
 			$ex_args['fields']         = 'ids';
-			$ex_args['posts_per_page'] = $this->max_posts;
+			// This needs to be -1 so that excluding posts isn't restricted to affect posts to not be excluded properly.
+			$ex_args['posts_per_page'] = -1;
 
 			// Exclude (method) query.
 			$q_exclude                 = new WP_Query( $ex_args );


### PR DESCRIPTION
Issue #2546

## Proposed changes

Fixes posts not being excluded properly when the max posts is set when Sitemap Indexes is enabled

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

1. On a new site, install the master branch and enable the sitemap module
2. Now create a hundred posts in the Uncategorized category
3. Next, edit three posts  as follows:

- One post should be set to Noindex
- One post should be set to Exclude from Sitemap
- One post should be removed from Uncategorized and added to a new category that is excluded from the sitemap using the new Excluded Terms option in the sitemap module

4. View the sitemap, the three posts that have been excluded above should not appear in the sitemap_post.xml
5. Now go to the sitemap settings and set pagination to 50 and view the sitemap
6. You should see two post sitemaps (sitemap_post_1 snd sitemap_post_2). View each one and check to see if the posts set as Noindex and Exclude from Sitemap are excluded.  You should see that the only post that is excluded is the one assigned to the category that has been excluded using Excluded Terms

