### PR TITLE
Fix video sitemap PHP error with taxonomies

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -709,10 +709,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			// Exclude Terms element items.
 			$this->default_options['excl_terms']['initial_options'] = array();
 			$taxonomies_active = array();
-			if ( is_array( $this->options['aiosp_sitemap_taxonomies'] ) ) {
-				$taxonomies_active = $this->options['aiosp_sitemap_taxonomies'];
-			} elseif ( ! empty( $this->options['aiosp_sitemap_taxonomies'] ) ) {
-				$taxonomies_active = array( $this->options['aiosp_sitemap_taxonomies'] );
+			if ( is_array( $this->options[ $this->prefix . 'taxonomies' ] ) ) {
+				$taxonomies_active = $this->options[ $this->prefix . 'taxonomies' ];
+			} elseif ( ! empty( $this->options[ $this->prefix . 'taxonomies' ] ) ) {
+				$taxonomies_active = array( $this->options[ $this->prefix . 'taxonomies' ] );
 			}
 
 			$args_taxonomy_key = array_search( 'all', $taxonomies_active, true );


### PR DESCRIPTION
Issue #2561

## Proposed changes

Fixes a PHP error on the Video Sitemap (Pro)

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. This will require Pro & lines copied over.
2. Activate Video Sitemap.
3. Go to Video Sitemap settings.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
