### PR TITLE
Change review notice to display only on AIOSEOP screens

### DIFF
--- a/admin/display/notices/review-plugin-notice.php
+++ b/admin/display/notices/review-plugin-notice.php
@@ -18,7 +18,7 @@ function aioseop_notice_review_plugin() {
 		'slug'           => 'review_plugin',
 		'delay_time'     => 1036800,
 		'target'         => 'user',
-		'screens'        => array(),
+		'screens'        => array( 'aioseop' ),
 		'class'          => 'notice-info',
 		/* translators: %1$s is a placeholder, which means that it should not be translated. It will be replaced with the name of the plugin, All in One SEO Pack. */
 		'message'        => sprintf( __( 'You have been using %1$s for a while now. That is awesome! If you like %1$s, then please leave us a 5-star rating. Huge thanks in advance!', 'all-in-one-seo-pack' ), AIOSEOP_PLUGIN_NAME ),


### PR DESCRIPTION
Issue #2565

## Proposed changes

Changes the review notice to display only on AIOSEOP's screens.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions

### Setup

You'll need to reduce the delay time for this.

1. Go to admin/display/notices/review-plugin-notice.php
2. Change delay_time to 0.
3. Reset Notice.

```
function aioseop_reset_notice() {
	global $aioseop_notices;
	$aioseop_notices->reset_notice( 'review_plugin' );
}
add_action( 'admin_init', 'aioseop_reset_notice' );
```

#### **SQL Method**

Deleting notices in database

1. Go to localhost > phpMyAdmin, and go to target database table.
2. Go to wp_options.
3. Click Search tab, and in 'option_name' type `%aioseop%.
4. Delete `aioseop_notices`.

OR for user notices

1. Go to localhost > phpMyAdmin, and go to target database table.
2. Go to wp_usermeta.
3. Click Search tab, and in 'meta_key' type `%aioseop%.
4. Delete `aioseop_notice_*`.

### Testing notice

1. Go to a WP screen, and notice should not display.
2. Go to AIOSEOP's ccreen, and notice should display.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
