### PR TITLE
Fix missing tabs when .hide is used by other plugins

### DIFF
--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -1217,6 +1217,11 @@ div.aioseop_notice a.aioseop_dismiss_link {
 	width: 98%;
 }
 
+.aioseop_tabs.hide,
+.aioseop_header_tabs.hide {
+	display: block !important;
+}
+
 .aioseop_header_tabs li a.aioseop_header_tab {
 	font-size: 14px;
 	line-height: 37px;


### PR DESCRIPTION
Issue #2572

## Proposed changes
This fixes a conflict where other plugins use the .hide class by adding back styles removed in v3.0

## Types of changes
What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Install and activate AIO v3.0 and this plugin - https://wordpress.org/plugins/accelerated-mobile-pages/
- Activate the Social Meta module
- Go to Posts > Add New and you should see that the Main Settings and Social Settings tabs are missing
- Now install this PR and verify the tabs are back

## Further comments
@EkoJR When testing, please check whether adding this style back affects anything else.  I don't know what the reason was for removing the style in the first place.