### PR TITLE
Only show notices for PHP > 5.3.6

### DIFF
--- a/admin/class-aioseop-notices.php
+++ b/admin/class-aioseop-notices.php
@@ -112,6 +112,12 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 		 * @since 3.0
 		 */
 		public function __construct() {
+			
+			// DirectoryIterator::getExtension() was added in PHP 5.3.6. We can remove this once we drop support < PHP 5.3.
+			if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
+			    return false;
+			}
+			
 			$this->_requires();
 			if ( current_user_can( 'aiosp_manage_seo' ) ) {
 


### PR DESCRIPTION
Issue #2580 

## Proposed changes

In 3.0, we introduced a new notices class. This class makes use of DirectoryIterator->getExtension which wasn't introduced until PHP 5.3.6.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- On a fresh site, install WordPress < 5.2 (WordPress 5.2 requires PHP > 5.6)
- Install PHP 5.2.4
- Install All in One SEO Pack
- Verify the fatal error
- Then verify this PR fixes it.
- Bonus: perform this same test when upgrading from an earlier version of AIOSEOP (pre-3.0)

## Further comments

This will make notices not work at all if they're running PHP < 5.3.6, but there won't be a fatal error.