### PR TITLE
restrict WC notice to our own screens 

### DIFF
--- a/admin/display/notices/wc-detected-notice.php
+++ b/admin/display/notices/wc-detected-notice.php
@@ -23,7 +23,7 @@ function aioseop_notice_pro_promo_woocommerce() {
 
 		'class'          => 'notice-info',
 		'target'         => 'site',
-		'screens'        => array(),
+		'screens'        => array( 'aioseop' ),
 		'action_options' => array(
 			array(
 				'time'    => 0,


### PR DESCRIPTION
Issue #2583

## Proposed changes

Because a handful of users are experiencing problems with getting a dismissed notice to stay dismissed, we should at least restrict it to our own screens, which is the more considerate option anyway, and probably what we should have done from the start.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Install both AIOSEOP and WooCommerce to trigger the notice.
- Bonus: test on a site having the persistence problems.