### PR TITLE
disable review request notice 

### DIFF
--- a/admin/class-aioseop-notices.php
+++ b/admin/class-aioseop-notices.php
@@ -115,7 +115,7 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 
 			// DirectoryIterator::getExtension() was added in PHP 5.3.6. We can remove this once we drop support < PHP 5.3.
 			if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
-			    return false;
+				return false;
 			}
 
 			$this->_requires();
@@ -730,7 +730,7 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 			$current_screen  = get_current_screen();
 			$current_user_id = get_current_user_id();
 			foreach ( $this->active_notices as $a_notice_slug => $a_notice_time_display ) {
-				if( 'review_plugin' === $a_notice_slug ){
+				if ( 'review_plugin' === $a_notice_slug ) {
 					continue;
 				}
 				$notice_show = true;

--- a/admin/class-aioseop-notices.php
+++ b/admin/class-aioseop-notices.php
@@ -112,12 +112,12 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 		 * @since 3.0
 		 */
 		public function __construct() {
-			
+
 			// DirectoryIterator::getExtension() was added in PHP 5.3.6. We can remove this once we drop support < PHP 5.3.
 			if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
 			    return false;
 			}
-			
+
 			$this->_requires();
 			if ( current_user_can( 'aiosp_manage_seo' ) ) {
 
@@ -730,6 +730,9 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 			$current_screen  = get_current_screen();
 			$current_user_id = get_current_user_id();
 			foreach ( $this->active_notices as $a_notice_slug => $a_notice_time_display ) {
+				if( 'review_plugin' === $a_notice_slug ){
+					continue;
+				}
 				$notice_show = true;
 				$notice      = $this->get_notice( $a_notice_slug );
 

--- a/admin/display/notices/review-plugin-notice.php
+++ b/admin/display/notices/review-plugin-notice.php
@@ -45,4 +45,4 @@ function aioseop_notice_review_plugin() {
 		),
 	);
 }
-add_filter( 'aioseop_admin_notice-review_plugin', 'aioseop_notice_review_plugin' );
+// add_filter( 'aioseop_admin_notice-review_plugin', 'aioseop_notice_review_plugin' );


### PR DESCRIPTION
Issue #2589

## Proposed changes

Since some users are still having problems with dismissible notices not staying dismissed, we should temporarily disable this one from happening.

## Types of changes

What types of changes does your code introduce?

- Removing old code/functionality (actually it just comments out)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Make sure you can reliably trigger the notice.
- Apply this patch and make sure the notice no longer appears and that there are no messages in the error log.

## Further comments

While it would be super nice if more users would leave us 5 star reviews, we probably don't want to request it with a notice that (unintentionally) can't be dismissed. We never want to give users a bad experience, but we really really shouldn't give them a bad experience while asking for a review. 
:)