### PR TITLE
Don't start welcome screen if we're in Ajax

### DIFF
--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -72,13 +72,18 @@ class AIOSEOP_Updates {
 		$this->do_feature_updates();
 	}
 
+	/**
+	 * Calls the Welcome Screen.
+	 *
+	 * since 2.3.9.2
+	 * since 3.0 Don't fire if we're doing Ajax or not in the admin.
+	 */
 	function aioseop_welcome() {
-		if ( get_transient( '_aioseop_activation_redirect' ) ) {
+		if ( ( ! DOING_AJAX || ! defined( 'DOING_AJAX' ) ) && is_admin() && get_transient( '_aioseop_activation_redirect' ) ) {
 			delete_transient( '_aioseop_activation_redirect' );
 			$aioseop_welcome = new aioseop_welcome();
 			$aioseop_welcome->init( true );
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
Issue #2576 

## Proposed changes

The bug is that our Welcome Screen stuff injects itself in during a bulk-update (sometimes) and causes a one-time failure for a subsequent plugin updating.
I've put in checks for whether we're in ajax.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions
- Testing is tricky.
- Follow the steps in the issue to reproduce the bug. Make sure you can reliably reproduce it. https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/2576#issuecomment-499249701
- The problem is, when update testing, you're getting the 3.0.2 code from .org instead of the patch. We'll need to figure out a way to intercept that for testing purposes.

