### PR TITLE
Fix aioseop_notice not loading database for users w/o 'aiosp_manage_seo' capabilities

### DIFF
--- a/admin/class-aioseop-notices.php
+++ b/admin/class-aioseop-notices.php
@@ -117,10 +117,11 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 			if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
 			    return false;
 			}
-			
-			$this->_requires();
-			if ( current_user_can( 'aiosp_manage_seo' ) ) {
 
+			$this->_requires();
+			$this->obj_load_options();
+
+			if ( current_user_can( 'aiosp_manage_seo' ) ) {
 				$this->aioseop_screens[] = 'toplevel_page_' . AIOSEOP_PLUGIN_DIRNAME . '/aioseop_class';
 				$this->aioseop_screens[] = 'all-in-one-seo_page_' . AIOSEOP_PLUGIN_DIRNAME . '/modules/aioseop_performance';
 				$this->aioseop_screens[] = 'all-in-one-seo_page_' . AIOSEOP_PLUGIN_DIRNAME . '/modules/aioseop_sitemap';
@@ -131,8 +132,6 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 				$this->aioseop_screens[] = 'all-in-one-seo_page_' . AIOSEOP_PLUGIN_DIRNAME . '/modules/aioseop_importer_exporter';
 				$this->aioseop_screens[] = 'all-in-one-seo_page_' . AIOSEOP_PLUGIN_DIRNAME . '/modules/aioseop_bad_robots';
 				$this->aioseop_screens[] = 'all-in-one-seo_page_' . AIOSEOP_PLUGIN_DIRNAME . '/modules/aioseop_feature_manager';
-
-				$this->obj_load_options();
 
 				add_action( 'admin_init', array( $this, 'init' ) );
 				add_action( 'current_screen', array( $this, 'admin_screen' ) );
@@ -549,6 +548,7 @@ if ( ! class_exists( 'AIOSEOP_Notices' ) ) {
 			}
 
 			$this->notices[ $slug ]['time_set'] = $time_set;
+			$this->notices[ $slug ]['time_start'] = $display_time;
 			$this->active_notices[ $slug ]      = $display_time;
 
 			return true;

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3503,10 +3503,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @since 3.0 Changed to AIOSEOP Notices.
 	 */
 	public function woo_upgrade_notice() {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-
 		global $aioseop_notices;
 		if ( class_exists( 'WooCommerce' ) && ! AIOSEOPPRO ) {
 			$aioseop_notices->activate_notice( 'woocommerce_detected' );

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3503,8 +3503,12 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @since 3.0 Changed to AIOSEOP Notices.
 	 */
 	public function woo_upgrade_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		global $aioseop_notices;
-		if ( class_exists( 'WooCommerce' ) && current_user_can( 'manage_options' ) && ! AIOSEOPPRO ) {
+		if ( class_exists( 'WooCommerce' ) && ! AIOSEOPPRO ) {
 			$aioseop_notices->activate_notice( 'woocommerce_detected' );
 		} else {
 			global $aioseop_notices;


### PR DESCRIPTION
Issue #2556

## Proposed changes

Fixes aioseop_notices not loading database values with non-admins (users without `aiosp_manage_seo` capabilities), and causing the notices to reset when non-admin users browsed wp-admin.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
This will need 2 users. 1 as the main admin, the other as an Editor.

1. Go to Settings > Reading and enable "Discourage search engines from indexing this site" to trigger `blog_public_disabled`.
2. Browse admin as the site admin to set WC notice.
3. With notice displayed, click 'No thanks' to delay notice.
4. In a different browser (or log out and log in as editor), browse site as an Editor. (the bug would trigger a reset)
5. Go back other user, and browse as site admin. Notice should not appear.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
