### PR TITLE
remove upgrade link from pro #2602

### DIFF
--- a/admin/display/menu.php
+++ b/admin/display/menu.php
@@ -18,7 +18,7 @@ class AIOSEOPAdminMenus {
 			return;
 		}
 
-		if ( current_user_can( 'manage_options' ) || current_user_can( 'aiosp_manage_seo' ) ) {
+		if ( ! AIOSEOPPRO && ( current_user_can( 'manage_options' ) || current_user_can( 'aiosp_manage_seo' ) ) ) {
 			add_action( 'admin_menu', array( $this, 'add_pro_submenu' ), 11 );
 		} else {
 			return;


### PR DESCRIPTION
Issue #2602 

## Proposed changes

In #2282 https://github.com/semperfiwebdesign/all-in-one-seo-pack/commit/f2b6eca55f491b14ddcc8abe987a0e50c362c026 we changed the hard-coded menu URL to relative, which had the inadvertent result of  introducing the upgrade link to Pro users.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
- Test both free and pro. 
- Free should have the link, Pro shouldn't.

## Further comments

This is going to be released in 3.0.3.1 Pro immediately, but will just get rolled into 3.0.4 later.