### PR TITLE
Change XML Sitemap naming convention to fix index paginated filenames

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -4,7 +4,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for WordPress. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 50 million downloads since 2007.
-Version: 3.0.4
+Version: 3.1
 Author: Michael Torbert
 Author URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Text Domain: all-in-one-seo-pack
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The original WordPress SEO plugin.
  *
  * @package All-in-One-SEO-Pack
- * @version 3.0.4
+ * @version 3.1
  */
 
 if ( ! defined( 'AIOSEOPPRO' ) ) {
@@ -42,7 +42,7 @@ if ( ! defined( 'AIOSEOP_PLUGIN_NAME' ) ) {
 	define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack' );
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '3.0.4' );
+	define( 'AIOSEOP_VERSION', '3.1' );
 }
 
 /*

--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -331,13 +331,15 @@ class AIOSEOP_Updates {
 		$aioseop_notices->reset_notice( 'review_plugin' );
 		$aioseop_notices->remove_notice( 'review_plugin' );
 	}
-}
 
 	/**
-    * Flushes rewrite rules for XML Sitemap URL changes
+	 * Flushes rewrite rules for XML Sitemap URL changes
 	 *
 	 * @since 3.1
-    */
-	public function reset_flush_rewrite_rules_201906(){
+	 */
+	public function reset_flush_rewrite_rules_201906() {
 		add_action( 'shutdown', 'flush_rewrite_rules');
 	}
+}
+
+

--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -133,6 +133,12 @@ class AIOSEOP_Updates {
 		) {
 			$this->reset_review_notice_201906();
 		}
+
+		if (
+		version_compare( $old_version, '3.1', '<' )
+		) {
+			$this->reset_flush_rewrite_rules_201906();
+		}
 	}
 
 	/**
@@ -326,3 +332,12 @@ class AIOSEOP_Updates {
 		$aioseop_notices->remove_notice( 'review_plugin' );
 	}
 }
+
+	/**
+    * Flushes rewrite rules for XML Sitemap URL changes
+	 *
+	 * @since 3.1
+    */
+	public function reset_flush_rewrite_rules_201906(){
+		add_action( 'shutdown', 'flush_rewrite_rules');
+	}

--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -135,7 +135,7 @@ class AIOSEOP_Updates {
 		}
 
 		if (
-		version_compare( $old_version, '3.1', '<' )
+				version_compare( $old_version, '3.1', '<' )
 		) {
 			$this->reset_flush_rewrite_rules_201906();
 		}
@@ -338,7 +338,7 @@ class AIOSEOP_Updates {
 	 * @since 3.1
 	 */
 	public function reset_flush_rewrite_rules_201906() {
-		add_action( 'shutdown', 'flush_rewrite_rules');
+		add_action( 'shutdown', 'flush_rewrite_rules' );
 	}
 }
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1436,7 +1436,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		public function get_rewrite_rules( $prefix_removed_rules_with = null ) {
 			$sitemap_rules  = array(
 				$this->get_filename() . '.xml'           => 'index.php?' . $this->prefix . 'path=root',
-				$this->get_filename() . '_(.+)(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
+				$this->get_filename() . '_(.+).(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
 				$this->get_filename() . '_(.+).xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);
 

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1434,10 +1434,11 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 * @return array
 		 */
 		public function get_rewrite_rules( $prefix_removed_rules_with = null ) {
+
 			$sitemap_rules  = array(
 				$this->get_filename() . '.xml'           => 'index.php?' . $this->prefix . 'path=root',
-				$this->get_filename() . '_(.+).(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
-				$this->get_filename() . '_(.+).xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
+				'(.+)-' . $this->get_filename() . '(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
+				'_(.+)' . $this->get_filename() . '.xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);
 
 			if ( isset( $this->options[ "{$this->prefix}rss_sitemap" ] ) && $this->options[ "{$this->prefix}rss_sitemap" ] ) {
@@ -2027,21 +2028,21 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							$count = 1;
 							for ( $post_count = 0; $post_count < $post_counts[ $sm ]; $post_count += $this->max_posts ) {
 								$files[] = array(
-									'loc'        => aioseop_home_url( '/' . $prefix . '_' . $sm . ( $count ++ ) . $suffix ),
+									'loc'        => aioseop_home_url( '/' . $sm . '-' . $prefix . ( $count ++ ) . $suffix ),
 									'changefreq' => $freq,
 									'priority'   => $prio,
 								);
 							}
 						} else {
 							$files[] = array(
-								'loc'        => aioseop_home_url( '/' . $prefix . '_' . $sm . $suffix ),
+								'loc'        => aioseop_home_url( '/' . $sm . '-' . $prefix . $suffix ),
 								'changefreq' => $freq,
 								'priority'   => $prio,
 							);
 						}
 					} else {
 						$files[] = array(
-							'loc'        => aioseop_home_url( '/' . $prefix . '_' . $sm . $suffix ),
+							'loc'        => aioseop_home_url( '/' . $sm . '-' . $prefix . $suffix ),
 							'changefreq' => $freq,
 							'priority'   => $prio,
 						);

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -2051,14 +2051,14 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 			if ( $this->option_isset( 'archive' ) ) {
 				$files[] = array(
-					'loc'        => aioseop_home_url( '/' . $prefix . '_archive' . $suffix ),
+					'loc'        => aioseop_home_url( '/' . 'archive-' . $prefix . $suffix ),
 					'changefreq' => $this->get_default_frequency( 'archive' ),
 					'priority'   => $this->get_default_priority( 'archive' ),
 				);
 			}
 			if ( $this->option_isset( 'author' ) ) {
 				$files[] = array(
-					'loc'        => aioseop_home_url( '/' . $prefix . '_author' . $suffix ),
+					'loc'        => aioseop_home_url( '/' . 'author-' . $prefix . $suffix ),
 					'changefreq' => $this->get_default_frequency( 'author' ),
 					'priority'   => $this->get_default_priority( 'author' ),
 				);
@@ -2076,21 +2076,21 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 								$count = 1;
 								for ( $tc = 0; $tc < $term_count; $tc += $this->max_posts ) {
 									$files[] = array(
-										'loc'        => aioseop_home_url( '/' . $prefix . '_' . $v1_taxonomy . '_' . ( $count ++ ) . $suffix ),
+										'loc'        => aioseop_home_url( '/' . $v1_taxonomy . '-' . $prefix . ( $count ++ ) . $suffix ),
 										'changefreq' => $this->get_default_frequency( 'taxonomies' ),
 										'priority'   => $this->get_default_priority( 'taxonomies' ),
 									);
 								}
 							} else {
 								$files[] = array(
-									'loc'        => aioseop_home_url( '/' . $prefix . '_' . $v1_taxonomy . $suffix ),
+									'loc'        => aioseop_home_url( '/' . $v1_taxonomy . '-' . $prefix . $suffix ),
 									'changefreq' => $this->get_default_frequency( 'taxonomies' ),
 									'priority'   => $this->get_default_priority( 'taxonomies' ),
 								);
 							}
 						} else {
 							$files[] = array(
-								'loc'        => aioseop_home_url( '/' . $prefix . '_' . $v1_taxonomy . $suffix ),
+								'loc'        => aioseop_home_url( '/' . $v1_taxonomy . '-' . $prefix . $suffix ),
 								'changefreq' => $this->get_default_frequency( 'taxonomies' ),
 								'priority'   => $this->get_default_priority( 'taxonomies' ),
 							);
@@ -2163,7 +2163,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				if ( 'root' === $sitemap_type ) {
 					$filename = $this->get_filename();
 				} else {
-					$filename = $this->get_filename() . '_' . $sitemap_type;
+					$filename = $sitemap_type . '-' . $this->get_filename();
 				}
 			}
 			if ( empty( $comment ) ) {
@@ -2212,7 +2212,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 					if ( ! empty( $this->options[ "{$this->prefix}indexes" ] ) && ( $post_counts[ $posttype ] > $this->max_posts ) ) {
 						$count = 1;
 						for ( $post_count = 0; $post_count < $post_counts[ $posttype ]; $post_count += $this->max_posts ) {
-							$this->do_write_sitemap( $posttype, $count - 1, $this->get_filename() . "_{$posttype}_{$count}" );
+							$this->do_write_sitemap( $posttype, $count - 1, "{$posttype}-" . $this->get_filename() . "{$count}" );
 							$count ++;
 						}
 					} else {
@@ -2229,7 +2229,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							if ( $term_count > $this->max_posts ) {
 								$count = 1;
 								for ( $tc = 0; $tc < $term_count; $tc += $this->max_posts ) {
-									$this->do_write_sitemap( $taxonomy, $tc, $this->get_filename() . "_{$taxonomy}_{$count}" );
+									$this->do_write_sitemap( $taxonomy, $tc, "{$taxonomy}-" . $this->get_filename() . "{$count}" );
 									$count ++;
 								}
 							} else {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1438,7 +1438,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$sitemap_rules  = array(
 				$this->get_filename() . '.xml'           => 'index.php?' . $this->prefix . 'path=root',
 				'(.+)-' . $this->get_filename() . '(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
-				'_(.+)' . $this->get_filename() . '.xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
+				'(.+)-' . $this->get_filename() . '.xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);
 
 			if ( isset( $this->options[ "{$this->prefix}rss_sitemap" ] ) && $this->options[ "{$this->prefix}rss_sitemap" ] ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1435,9 +1435,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_rewrite_rules( $prefix_removed_rules_with = null ) {
 			$sitemap_rules  = array(
-				$this->get_filename() . '.xml'            => 'index.php?' . $this->prefix . 'path=root',
+				$this->get_filename() . '.xml'           => 'index.php?' . $this->prefix . 'path=root',
 				$this->get_filename() . '_(.+)(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
-				$this->get_filename() . '_(.+).xml'       => 'index.php?' . $this->prefix . 'path=$matches[1]',
+				$this->get_filename() . '_(.+).xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);
 
 			if ( isset( $this->options[ "{$this->prefix}rss_sitemap" ] ) && $this->options[ "{$this->prefix}rss_sitemap" ] ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1953,7 +1953,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$options[ "{$this->prefix}posttypes" ]  = array_diff( $options[ "{$this->prefix}posttypes" ], array( 'all' ) );
 			$options[ "{$this->prefix}taxonomies" ] = $this->show_or_hide_taxonomy( array_diff( $options[ "{$this->prefix}taxonomies" ], array( 'all' ) ) );
 
-			$files[] = array( 'loc' => aioseop_home_url( '/' . $prefix . '_addl' . $suffix ) );
+			$files[] = array( 'loc' => aioseop_home_url( '/addl-' . $prefix . $suffix ) );
 
 			// Get post types selected, and NoIndex post types & Index posts.
 			$post_types = $options[ "{$this->prefix}posttypes" ];

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1436,7 +1436,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		public function get_rewrite_rules( $prefix_removed_rules_with = null ) {
 			$sitemap_rules  = array(
 				$this->get_filename() . '.xml'            => 'index.php?' . $this->prefix . 'path=root',
-				$this->get_filename() . '_(.+)_(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
+				$this->get_filename() . '_(.+)(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
 				$this->get_filename() . '_(.+).xml'       => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);
 
@@ -2027,7 +2027,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 							$count = 1;
 							for ( $post_count = 0; $post_count < $post_counts[ $sm ]; $post_count += $this->max_posts ) {
 								$files[] = array(
-									'loc'        => aioseop_home_url( '/' . $prefix . '_' . $sm . '_' . ( $count ++ ) . $suffix ),
+									'loc'        => aioseop_home_url( '/' . $prefix . '_' . $sm . ( $count ++ ) . $suffix ),
 									'changefreq' => $freq,
 									'priority'   => $prio,
 								);

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -1436,7 +1436,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		public function get_rewrite_rules( $prefix_removed_rules_with = null ) {
 
 			$sitemap_rules  = array(
-				$this->get_filename() . '.xml'           => 'index.php?' . $this->prefix . 'path=root',
+				$this->get_filename() . '.xml'                => 'index.php?' . $this->prefix . 'path=root',
 				'(.+)-' . $this->get_filename() . '(\d+).xml' => 'index.php?' . $this->prefix . 'path=$matches[1]&' . $this->prefix . 'page=$matches[2]',
 				'(.+)-' . $this->get_filename() . '.xml'      => 'index.php?' . $this->prefix . 'path=$matches[1]',
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hallsofmontezuma, semperplugins, wpsmort, arnaudbroes
 Tags: SEO, Google Search Console, XML Sitemap, meta description, meta title, noindex
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 3.0.4
+Stable tag: 3.1
 License: GPLv2 or later
 Requires PHP: 5.2.4
 


### PR DESCRIPTION
Issue #2554 

## Proposed changes

Google appears to have made an undocumented change where paginated XML Sitemap filenames with "_post_" proceeding the number no longer get found by Google Search Console.
This removes the underscore, and flips the "post" and "sitemap". We're flipping them because regex seemed to have issues with "sitemap" and the number right next to each other.

Previous: sitemap_post_1.xml, sitemap_post_2.xml
New: post_sitemap1.xml, post_sitemap2.xml

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Improves existing functionality
- Improves existing code

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Make sure you can verify the bug on a fresh site. 
- Make sure the plugin version number is < 3.1
- Drop in the new plugin files
- Go straight to the sitemap.xml file, do not go to wp-admin