### PR TITLE
Fix for PHP notice when no posts present on homepage

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1473,10 +1473,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 			// #1616 - Avoid trying to get property of non-object when no posts are present on the homepage
 			global $post;
-			$frontpage_id = get_option( 'page_on_front' );
 
 			if ( $post === null ) {
-				$post_id = $frontpage_id;
+				$post_id = get_option( 'page_on_front' );
 			} else {
 				$post_id = $post->ID;
 			}
@@ -1488,7 +1487,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				}
 				// $title = $this->internationalize( $aioseop_options['aiosp_home_title'] );
 				if ( ! $title ) {
-					$title = $this->internationalize( get_post_meta( $frontpage_id, '_aioseop_title', true ) );
+					$title = $this->internationalize( get_post_meta( $post_id, '_aioseop_title', true ) );
 				} // This is/was causing the first product to come through.
 				if ( ! $title ) {
 					$title = $this->internationalize( $post->post_title );

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1471,8 +1471,15 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				$title = $this->internationalize( get_option( 'blogname' ) ) . ' | ' . $this->internationalize( get_bloginfo( 'description' ) );
 			}
 
+			// #1616 - Avoid trying to get property of non-object when no posts are present on the homepage
 			global $post;
-			$post_id = $post->ID;
+			$frontpage_id = get_option( 'page_on_front' );
+
+			if ( $post === null ) {
+				$post_id = $frontpage_id;
+			} else {
+				$post_id = $post->ID;
+			}
 
 			if ( is_post_type_archive() && is_post_type_archive( 'product' ) && $post_id = wc_get_page_id( 'shop' ) && $post = get_post( $post_id ) ) {
 				$frontpage_id = get_option( 'page_on_front' );

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1471,7 +1471,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				$title = $this->internationalize( get_option( 'blogname' ) ) . ' | ' . $this->internationalize( get_bloginfo( 'description' ) );
 			}
 
-			// #1616 - Avoid trying to get property of non-object when no posts are present on the homepage
+			// #1616 - Avoid trying to get property of non-object when no posts are present on the homepage.
 			global $post;
 
 			if ( $post === null ) {

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1482,7 +1482,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 
 			if ( is_post_type_archive() && is_post_type_archive( 'product' ) && $post_id = wc_get_page_id( 'shop' ) && $post = get_post( $post_id ) ) {
-				$frontpage_id = get_option( 'page_on_front' );
 
 				if ( wc_get_page_id( 'shop' ) == get_option( 'page_on_front' ) && ! empty( $aioseop_options['aiosp_use_static_home_info'] ) ) {
 					$title = $this->internationalize( get_post_meta( $post->ID, '_aioseop_title', true ) );


### PR DESCRIPTION
Issue #1616

## Proposed changes
When you have Reading Settings set to Your homepage displays "Your latest posts" and there are no published posts, a PHP notice of Trying to get property of non-object is returned.  This PR adds checks for this.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. On a new or existing site, set Your homepage displays to "Your latest posts"
2. Make sure there are no published posts
3. Verify you get the PHP notice when you visit the homepage
4. Install the code from this PR and visit the homepage to verify you no longer get the notice
5. Test all combinations of settings for Your homepage displays along with all combinations of Home Page Settings in AIO to verify that you get the correct doc title and no errors/notices each time

