### PR TITLE
Add %current_month% macro

### DIFF
--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -161,6 +161,9 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					/* translators: %s is replaced with a time related term such as Date, Year, Month, etc. */
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					/* translators: %s is replaced with a time related term such as Date, Year, Month, etc. */
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%cf_fieldname%</dt>' .
 					'<dd>' . __( 'The name of a custom field', 'all-in-one-seo-pack' ) . '</dd>' .
 				'</dl>',
@@ -187,6 +190,8 @@ class AIOSEOP_Helper {
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), __( 'Page', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_year%</dt>' .
@@ -221,6 +226,8 @@ class AIOSEOP_Helper {
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), __( 'Post', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_year%</dt>' .
@@ -244,7 +251,9 @@ class AIOSEOP_Helper {
 					/* translators: %s is replaced with a content type such as Post, Page, etc. */
 					'<dd>' . sprintf( __( 'The description of the %s', 'all-in-one-seo-pack' ), __( 'Category', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_year%</dt>' .
-					'<dd>' . __( 'The current year', 'all-in-one-seo-pack' ) . '</dd>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 				'</dl>',
 			'aiosp_archive_title_format'        =>
 				__( 'This controls the format of the title tag for Custom Post Archives.', 'all-in-one-seo-pack' ) . '<br />' .
@@ -328,6 +337,8 @@ class AIOSEOP_Helper {
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf(
 						__( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ),
@@ -467,6 +478,8 @@ class AIOSEOP_Helper {
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), $name ) . '</dd>' .
 					'<dt>%post_year%</dt>' .

--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -162,6 +162,8 @@ class AIOSEOP_Helper {
 					/* translators: %s is replaced with a time related term such as Date, Year, Month, etc. */
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					/* translators: %s is replaced with a time related term such as Date, Year, Month, etc. */
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%cf_fieldname%</dt>' .
@@ -191,6 +193,8 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), __( 'Page', 'all-in-one-seo-pack' ) ) . '</dd>' .
@@ -227,6 +231,8 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), __( 'Post', 'all-in-one-seo-pack' ) ) . '</dd>' .
@@ -253,6 +259,8 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 				'</dl>',
 			'aiosp_archive_title_format'        =>
@@ -338,6 +346,8 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf(
@@ -479,6 +489,8 @@ class AIOSEOP_Helper {
 					'<dt>%current_year%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'year', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%current_month%</dt>' .
+					'<dd>' . sprintf( __( 'The current %s', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
+					'<dt>%current_month_i18n%</dt>' .
 					'<dd>' . sprintf( __( 'The current %s (localized)', 'all-in-one-seo-pack' ), __( 'month', 'all-in-one-seo-pack' ) ) . '</dd>' .
 					'<dt>%post_date%</dt>' .
 					'<dd>' . sprintf( __( 'The %1$s when the %2$s was published (localized)', 'all-in-one-seo-pack' ), __( 'date', 'all-in-one-seo-pack' ), $name ) . '</dd>' .

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1031,7 +1031,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$title_format = str_replace( '%current_year%', date( 'Y' ), $title_format );
 		}
 		if ( false !== strpos( $title_format, '%current_month%', 0 ) ) {
-			$title_format = str_replace( '%current_month%', date_i18n( 'M' ), $title_format );
+			$title_format = str_replace( '%current_month%', date( 'M' ), $title_format );
+		}
+		if ( false !== strpos( $title_format, '%current_month_i18n%', 0 ) ) {
+			$title_format = str_replace( '%current_month_i18n%', date_i18n( 'M' ), $title_format );
 		}
 		if ( false !== strpos( $title_format, '%post_date%', 0 ) ) {
 			$title_format = str_replace( '%post_date%', aioseop_formatted_date( get_the_time( 'U' ) ), $title_format );
@@ -2016,7 +2019,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$new_title = str_replace( '%current_year%', date( 'Y' ), $new_title );
 		}
 		if ( false !== strpos( $new_title, '%current_month%', 0 ) ) {
-			$new_title = str_replace( '%current_month%', date_i18n( 'M' ), $new_title );
+			$new_title = str_replace( '%current_month%', date( 'M' ), $new_title );
+		}
+		if ( false !== strpos( $new_title, '%current_month_i18n%', 0 ) ) {
+			$new_title = str_replace( '%current_month_i18n%', date_i18n( 'M' ), $new_title );
 		}
 		if ( false !== strpos( $new_title, '%post_date%', 0 ) ) {
 			$new_title = str_replace( '%post_date%', aioseop_formatted_date( get_the_date( 'U' ) ), $new_title );
@@ -2385,7 +2391,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$title = str_replace( '%current_year%', date( 'Y' ), $title );
 		}
 		if ( false !== strpos( $title, '%current_month%', 0 ) ) {
-			$title = str_replace( '%current_month%', date_i18n( 'M' ), $title );
+			$title = str_replace( '%current_month%', date( 'M' ), $title );
+		}
+		if ( false !== strpos( $title, '%current_month_i18n%', 0 ) ) {
+			$title = str_replace( '%current_month_i18n%', date_i18n( 'M' ), $title );
 		}
 
 		/**
@@ -4283,7 +4292,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$description = str_replace( '%current_year%', date( 'Y' ), $description );
 		}
 		if ( false !== strpos( $description, '%current_month%', 0 ) ) {
-			$description = str_replace( '%current_month%', date_i18n( 'M' ), $description );
+			$description = str_replace( '%current_month%', date( 'M' ), $description );
+		}
+		if ( false !== strpos( $description, '%current_month_i18n%', 0 ) ) {
+			$description = str_replace( '%current_month_i18n%', date_i18n( 'M' ), $description );
 		}
 		if ( false !== strpos( $description, '%post_date%', 0 ) ) {
 			$description = str_replace( '%post_date%', get_the_date(), $description );

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1030,6 +1030,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( false !== strpos( $title_format, '%current_year%', 0 ) ) {
 			$title_format = str_replace( '%current_year%', date( 'Y' ), $title_format );
 		}
+		if ( false !== strpos( $title_format, '%current_month%', 0 ) ) {
+			$title_format = str_replace( '%current_month%', date_i18n( 'M' ), $title_format );
+		}
 		if ( false !== strpos( $title_format, '%post_date%', 0 ) ) {
 			$title_format = str_replace( '%post_date%', aioseop_formatted_date( get_the_time( 'U' ) ), $title_format );
 		}
@@ -2012,6 +2015,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( false !== strpos( $new_title, '%current_year%', 0 ) ) {
 			$new_title = str_replace( '%current_year%', date( 'Y' ), $new_title );
 		}
+		if ( false !== strpos( $new_title, '%current_month%', 0 ) ) {
+			$new_title = str_replace( '%current_month%', date_i18n( 'M' ), $new_title );
+		}
 		if ( false !== strpos( $new_title, '%post_date%', 0 ) ) {
 			$new_title = str_replace( '%post_date%', aioseop_formatted_date( get_the_date( 'U' ) ), $new_title );
 		}
@@ -2377,6 +2383,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 		if ( false !== strpos( $title, '%current_year%', 0 ) ) {
 			$title = str_replace( '%current_year%', date( 'Y' ), $title );
+		}
+		if ( false !== strpos( $title, '%current_month%', 0 ) ) {
+			$title = str_replace( '%current_month%', date_i18n( 'M' ), $title );
 		}
 
 		/**
@@ -4272,6 +4281,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 		if ( false !== strpos( $description, '%current_year%', 0 ) ) {
 			$description = str_replace( '%current_year%', date( 'Y' ), $description );
+		}
+		if ( false !== strpos( $description, '%current_month%', 0 ) ) {
+			$description = str_replace( '%current_month%', date_i18n( 'M' ), $description );
 		}
 		if ( false !== strpos( $description, '%post_date%', 0 ) ) {
 			$description = str_replace( '%post_date%', get_the_date(), $description );


### PR DESCRIPTION
Issue #2301.

## Proposed changes

Adds the %current_month% title format macro to add the current month (localized) to the title.

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Check this in English and an non-Latin alphabet language such as Japanese (to see if it is localized) for the following title format fields:

- Homepage
- Post
- Page
- Category
- Description

You can ignore all (other) Grunt errors. The ones in these two files have been fixed but I think new Grunt errors are showing up now because @EkoJR changed some of the rules.

## Further comments

I'm not adding a unit test because #2387 needs to be resolved first.