### PR TITLE
Fix WooCommerce PHP memory limit warning

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -105,7 +105,7 @@ if ( ! defined( 'AIOSEOP_PLUGIN_IMAGES_URL' ) ) {
 	define( 'AIOSEOP_PLUGIN_IMAGES_URL', AIOSEOP_PLUGIN_URL . 'images/' );
 }
 if ( ! defined( 'AIOSEOP_BASELINE_MEM_LIMIT' ) ) {
-	define( 'AIOSEOP_BASELINE_MEM_LIMIT', 268435456 );
+	define( 'AIOSEOP_BASELINE_MEM_LIMIT', '256M' );
 } // 256MB
 if ( ! defined( 'WP_CONTENT_URL' ) ) {
 	define( 'WP_CONTENT_URL', site_url() . '/wp-content' );


### PR DESCRIPTION
Issue #869.

## Proposed changes

Fixes an issue where WooCommerce isn't able to properly parse the PHP memory limit All in One SEO Pack sets.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Check the following two things:

(1) All in One SEO Pack is still able to set the PHP memory limit.
(2) The warning on WooCommerce's status page has disappeared.
