### PR TITLE
Make plugin name constant dynamic

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -39,7 +39,12 @@ if ( ! defined( 'AIOSEOPPRO' ) ) {
 	define( 'AIOSEOPPRO', false );
 }
 if ( ! defined( 'AIOSEOP_PLUGIN_NAME' ) ) {
-	define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack' );
+	if ( !AIOSEOPPRO ) {
+		define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack' );
+	}
+	else {
+		define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack Pro' );
+	}
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
 	define( 'AIOSEOP_VERSION', '3.1' );


### PR DESCRIPTION
Issue #2609.

## Proposed changes

Makes the plugin name constant dynamic so we don't have to change it each time we build Pro.

## Types of changes

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
 
Check both free and Pro to make sure that everything looks good and check a tooltip (e.g. "Register imortant events" setting in General Settings menu) to see if the plugin name is correct.
