### PR TITLE
Remove obsolete string

### DIFF
--- a/inc/commonstrings.php
+++ b/inc/commonstrings.php
@@ -62,7 +62,6 @@ class AIOSP_Common_Strings {
 		__( 'Include Date Archives in your sitemap.', 'all-in-one-seo-pack' );
 		__( 'Include Author Archives in your sitemap.', 'all-in-one-seo-pack' );
 		__( 'Exclude Images in your sitemap.', 'all-in-one-seo-pack' );
-		__( 'Create a compressed sitemap file in .xml.gz format.', 'all-in-one-seo-pack' );
 		__( 'Places a link to your Sitemap.xml into your virtual Robots.txt file.', 'all-in-one-seo-pack' );
 		__( 'Dynamically creates the XML sitemap instead of using a static file.', 'all-in-one-seo-pack' );
 		__( 'If checked, only posts that have videos in them will be displayed on the sitemap.', 'all-in-one-seo-pack' );


### PR DESCRIPTION
Issue #2644

## Proposed changes

Removes an obsolete string that was linked to our sitemap compression feature.

## Types of changes

- Removing old code/functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Not much to test; just have a look at the code change.