### PR TITLE
Change naming and remove redundant arguments exclude_tax_terms filter

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4163,7 +4163,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				}
 			}
 
-			$args = apply_filters( $this->prefix . 'tax_args', $args, $page, $this->options );
+			$args = apply_filters( 'aioseop_sitemap_exclude_tax_terms', $args );
 
 			return $args;
 		}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4154,8 +4154,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 			$args['taxonomy'] = $this->show_or_hide_taxonomy( $taxonomies );
 
+			$args['exclude'] = array();
 			if ( $this->option_isset( 'excl_terms' ) ) {
-				$args['exclude'] = array();
 				foreach ( $taxonomies as $v1_taxonomy ) {
 					if ( isset( $this->options[ $this->prefix . 'excl_terms' ][ $v1_taxonomy ] ) ) {
 						$args['exclude'] = array_merge( $args['exclude'], $this->options[ $this->prefix . 'excl_terms' ][ $v1_taxonomy ]['terms'] );

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4163,6 +4163,18 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				}
 			}
 
+			/**
+			 * The aioseop_sitemap_exclude_tax_terms filter hook.
+			 *
+			 * Allows users to exclude (or include) taxonomy terms from the sitemap.
+			 *
+			 * @since 3.2.0
+			 *
+			 * @param array $args {
+			 *     @type array $taxonomy Name of the taxonomy that is being included in the sitemap.
+			 *     @type array $exclude IDs of taxonomy terms of the relevant taxonomy that need to be excluded.
+			 * }
+			 */
 			$args = apply_filters( 'aioseop_sitemap_exclude_tax_terms', $args );
 
 			return $args;

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4168,7 +4168,8 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			 *
 			 * Allows users to exclude (or include) taxonomy terms from the sitemap.
 			 *
-			 * @since 3.2.0
+			 * @since 2.9
+			 * @since 3.2.0 Rename filter hook & remove redundant params.
 			 *
 			 * @param array $args {
 			 *     @type array $taxonomy Name of the taxonomy that is being included in the sitemap.


### PR DESCRIPTION
Issue #746

## Proposed changes

Changes name of an existing filter and removes unnecessary arguments.

## Types of changes

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Use to code example here to test this filter - https://semperplugins.com/wp-admin/post.php?post=4958&action=edit&lang=en. 

If the filter works, please also review the documentation and publish it.