### PR TITLE
CSS fixes for alignment on Edit Post screen

### DIFF
--- a/css/modules/aioseop_module-rtl.css
+++ b/css/modules/aioseop_module-rtl.css
@@ -208,6 +208,10 @@ div.aioseop_feature {
 	float: left !important;
 }
 
+.postbox-container div#aiosp_upgrade_wrapper {
+	float: right;
+}
+
 #aiosp_settings_form .aioseop_no_label,
 .aioseop_no_label {
 	float: right;

--- a/css/modules/aioseop_module-rtl.css
+++ b/css/modules/aioseop_module-rtl.css
@@ -257,11 +257,6 @@ div.aioseop_notice a.aioseop_dismiss_link {
 	margin-right: 5px
 }
 
-.aioseop_tab {
-	padding-left: 0;
-	padding-right: 5px
-}
-
 form#aiosp_settings_form,
 .aioseop_tabs_div {
 	padding-right: 0;

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -83,8 +83,7 @@
 
 .aioseop_tabs .aioseop_meta_box_help,
 .aioseop_tabs .aioseop_meta_box_help:active {
-	margin-top: 4px;
-	margin-right: 45px;
+	margin-top: 10px;
 }
 
 .aioseop_label {

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -1452,7 +1452,7 @@ div#aiosp_snippet_wrapper {
     border: 1px solid #8d96a0;
     clear: both;
     padding: 10px 10px 0;
-    max-width: 97%;
+    width: auto;
     margin-bottom: 15px;
 }
 

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -86,6 +86,11 @@
 	margin-top: 10px;
 }
 
+.aioseop_tabs #aioseop_opengraph_settings .aioseop_meta_box_help,
+.aioseop_tabs #aioseop_opengraph_settings .aioseop_meta_box_help:active {
+	margin-bottom: 20px;
+}
+
 .aioseop_label {
 	color: #5F5F5F;
 	font-weight: 600;

--- a/css/modules/aioseop_module.css
+++ b/css/modules/aioseop_module.css
@@ -1401,6 +1401,7 @@ div.sfwd_debug_error {
 }
 
 .postbox-container .aioseop_input {
+	width: 100%;
 	margin-bottom: 10px;
 	padding: 0;
 }
@@ -1453,7 +1454,7 @@ div#aiosp_snippet_wrapper {
     clear: both;
     padding: 10px 10px 0;
     width: auto;
-    margin-bottom: 15px;
+    margin: 0 1px 15px;
 }
 
 #aiosp_snippet_wrapper > .aioseop_input:first-child {


### PR DESCRIPTION
Issue #2533

## Proposed changes
This fixes various alignment issues with the AIO meta box on the Edit Post screen both with Left-to-Right and Right-to-Left display.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
- Improves existing functionality
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Perform a visual check of the AIO meta box on the Edit Post screen
- Check in all modern browsers on Mac and PC
- Check both LTR and RTL screens (use the RTL Test plugin - https://wordpress.org/plugins/rtl-tester/)
- Check with the Classic Editor and Gutenberg Block Editor
Check with the Main Settings tab disabled and the Social Settings tab disabled
- Check all other screens to make sure no styles are incorrectly applied (check the code to make sure the only styles changed are the styles that apply to the Edit Post screen)
