### PR TITLE
Replaces links with buttons in Review notice

### DIFF
--- a/admin/display/notices/review-plugin-notice.php
+++ b/admin/display/notices/review-plugin-notice.php
@@ -28,19 +28,19 @@ function aioseop_notice_review_plugin() {
 				'text'    => __( 'Add a review', 'all-in-one-seo-pack' ),
 				'link'    => 'https://wordpress.org/support/plugin/all-in-one-seo-pack/reviews?rate=5#new-post',
 				'dismiss' => false,
-				'class'   => '',
+				'class'   => 'button-primary button-orange',
 			),
 			array(
 				'text'    => __( 'Remind me later', 'all-in-one-seo-pack' ),
 				'time'    => 432000,
 				'dismiss' => false,
-				'class'   => '',
+				'class'   => 'button-secondary',
 			),
 			array(
 				'time'    => 0,
 				'text'    => __( 'No, thanks', 'all-in-one-seo-pack' ),
 				'dismiss' => true,
-				'class'   => '',
+				'class'   => 'button-secondary',
 			),
 		),
 	);


### PR DESCRIPTION
Issue #2592

## Proposed changes
This replaces the plain link text with styled (standardized) buttons in the Review notice to improve the appearance of the notice.

## Types of changes

What types of changes does your code introduce?
- Improves existing functionality
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Install the code from this PR and then reverse the changes made in PR #2594 which disabled the Review notice
- Set the times in admin/display/notices/review-plugin-notice.php to 0
- Uncomment out the add_filter at the bottom of admin/display/notices/review-plugin-notice.php
- You should see the notice with the three buttons
- Verify the styling and functionality of the notice and buttons in all browsers on PC and Mac
