### PR TITLE
Rename Admin Bar to Toolbar

### DIFF
--- a/inc/commonstrings.php
+++ b/inc/commonstrings.php
@@ -28,7 +28,7 @@ class AIOSP_Common_Strings {
 		__( 'Use these checkboxes to select which Taxonomies you want to use %s with.', 'all-in-one-seo-pack' );
 		__( 'This displays an SEO News widget on the dashboard.', 'all-in-one-seo-pack' );
 		/* translators: %s is a placeholder, which means that it should not be translated. It will be replaced with the name of the plugin, All in One SEO Pack. */
-		__( 'Check this to add %s to the Admin Bar for easy access to your SEO settings.', 'all-in-one-seo-pack' );
+		__( 'Check this to add %s to the Toolbar for easy access to your SEO settings.', 'all-in-one-seo-pack' );
 		/* translators: %s is a placeholder, which means that it should not be translated. It will be replaced with the name of the plugin, All in One SEO Pack. */
 		__( 'Check this to move the %s menu item to the top of your WordPress Dashboard menu.', 'all-in-one-seo-pack' );
 		__( 'Check this if you want to track outbound forms with Google Analytics.', 'all-in-one-seo-pack' );
@@ -88,7 +88,7 @@ class AIOSP_Common_Strings {
 
 		// From functions_general.php.
 		__( 'Show SEO News', 'all-in-one-seo-pack' );
-		__( 'Display Menu In Admin Bar:', 'all-in-one-seo-pack' );
+		__( 'Display Menu In Toolbar:', 'all-in-one-seo-pack' );
 		__( 'Display Menu At The Top:', 'all-in-one-seo-pack' );
 		__( 'Track Outbound Forms:', 'all-in-one-seo-pack' );
 		__( 'Track Events:', 'all-in-one-seo-pack' );


### PR DESCRIPTION
Issue #2621

## Proposed changes
This renames the Admin Bar to Toolbar in the commonstrings file for translators.  See also https://github.com/semperfiwebdesign/aioseop-pro/pull/529

## Types of changes
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [x] I have created an issue for docs (https://github.com/semperfiwebdesign/semperpluginstore/issues/693).

## Testing instructions
Look at the code and verify the correct strings have been changed.