### PR TITLE
Replace parse_url with wp_parse_url 

### DIFF
--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -919,7 +919,7 @@ if ( ! function_exists( 'aioseop_mrt_exclude_this_page' ) ) {
 			if ( $url === null ) {
 				$url = $_SERVER['REQUEST_URI'];
 			} else {
-				$url = parse_url( $url );
+				$url = wp_parse_url( $url );
 				if ( ! empty( $url['path'] ) ) {
 					$url = $url['path'];
 				} else {

--- a/inc/aiosp_common.php
+++ b/inc/aiosp_common.php
@@ -148,7 +148,7 @@ class aiosp_common {
 		if ( 0 !== strpos( $url, 'http' ) && '/' !== $url ) {
 			if ( 0 === strpos( $url, '//' ) ) {
 				// for //<host>/resource type urls.
-				$scheme = parse_url( home_url(), PHP_URL_SCHEME );
+				$scheme = wp_parse_url( home_url(), PHP_URL_SCHEME );
 				$url    = $scheme . ':' . $url;
 			} else {
 				// for /resource type urls.
@@ -169,7 +169,7 @@ class aiosp_common {
 	 * @return string
 	 */
 	static function make_url_valid_smartly( $url ) {
-		$scheme = parse_url( home_url(), PHP_URL_SCHEME );
+		$scheme = wp_parse_url( home_url(), PHP_URL_SCHEME );
 		if ( 0 !== strpos( $url, 'http' ) ) {
 			if ( 0 === strpos( $url, '//' ) ) {
 				// for //<host>/resource type urls.

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -885,8 +885,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		 */
 		public function get_rewrite_url( $url ) {
 			global $wp_rewrite;
-			// TODO Change to wp_parse_url.
-			$url = parse_url( esc_url( $url ), PHP_URL_PATH );
+			$url = wp_parse_url( esc_url( $url ), PHP_URL_PATH );
 			$url = ltrim( $url, '/' );
 			if ( ! empty( $wp_rewrite ) ) {
 				$rewrite_rules = $wp_rewrite->rewrite_rules();
@@ -2648,8 +2647,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			// TODO Add esc_* function.
 			echo '<!-- ' . sprintf( $this->comment_string, $comment, AIOSEOP_VERSION, date( 'D, d M Y H:i:s e' ) ) . " -->\r\n";
 			$plugin_path  = $this->plugin_path['url'];
-			// TODO Change to wp_parse_url().
-			$plugin_url   = parse_url( $plugin_path );
+			$plugin_url   = wp_parse_url( $plugin_path );
 			$current_host = $_SERVER['HTTP_HOST'];
 			if ( empty( $current_host ) ) {
 				$current_host = $_SERVER['SERVER_NAME'];
@@ -3066,12 +3064,10 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		public function get_addl_pages_only() {
 			$pages = array();
 			if ( ! empty( $this->options[ $this->prefix . 'addl_pages' ] ) ) {
-				// TODO Change to wp_parse_url().
-				$siteurl = parse_url( aioseop_home_url() );
+				$siteurl = wp_parse_url( aioseop_home_url() );
 				foreach ( $this->options[ $this->prefix . 'addl_pages' ] as $k => $v ) {
 					$k   = aiosp_common::make_url_valid_smartly( $k );
-					// TODO Change to wp_parse_url().
-					$url = parse_url( $k );
+					$url = wp_parse_url( $k );
 					if ( empty( $url['host'] ) ) {
 						$url['host'] = $siteurl['host'];
 					}
@@ -4052,17 +4048,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 
 			// Make the url absolute, if its relative.
 			$image   = aiosp_common::absolutize_url( $image );
-			// TODO Change to wp_parse_url().
-			$extn    = pathinfo( parse_url( $image, PHP_URL_PATH ), PATHINFO_EXTENSION );
+			$extn    = pathinfo( wp_parse_url( $image, PHP_URL_PATH ), PATHINFO_EXTENSION );
 			$allowed = apply_filters( 'aioseop_allowed_image_extensions', self::$image_extensions );
 			// Bail if image does not refer to an image file otherwise Google Search Console might reject the sitemap.
 			if ( ! in_array( $extn, $allowed, true ) ) {
 				return false;
 			}
 
-			// TODO Change to wp_parse_url().
-			$image_host = parse_url( $image, PHP_URL_HOST );
-			$host       = parse_url( home_url(), PHP_URL_HOST );
+			$image_host = wp_parse_url( $image, PHP_URL_HOST );
+			$host       = wp_parse_url( home_url(), PHP_URL_HOST );
 
 			if ( $image_host !== $host ) {
 				// Allowed hosts will be provided in a wildcard format i.e. img.yahoo.* or *.akamai.*.

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4023,16 +4023,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 		}
 
 		/**
-		 * Is Image URL Valid
+		 * The is_image_url_valid() function.
 		 *
-		 * Validate the image.
-		 * NOTE: We will use parse_url here instead of wp_parse_url as we will correct the URLs beforehand and
-		 * this saves us the need to check PHP version support.
+		 * Checks whether the image URL is valid.
 		 *
 		 * @since 2.4.1
 		 * @since 2.4.3 Compatibility with Pre v4.7 wp_parse_url().
-		 * @since 2.11 Sitemap Optimization #2008 - Changed to a more appropriate name.
-		 * @since 3.0 remove checks for old WP versions
+		 * @since 2.11.0 Sitemap Optimization #2008 - Changed to a more appropriate name.
+		 * @since 3.0.0 Remove checks for old WP versions.
+		 * @since 3.2.0 Remove redundant code.
 		 *
 		 * @param string $image The image src.
 		 * @return bool
@@ -4043,12 +4042,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return false;
 			}
 
-			$component = PHP_URL_PATH;
-			$url       = wp_parse_url( $image, $component );
-
-			// Make the url absolute, if its relative.
-			$image   = aiosp_common::absolutize_url( $image );
-			$extn    = pathinfo( wp_parse_url( $image, PHP_URL_PATH ), PATHINFO_EXTENSION );
+			$extn    = pathinfo( $image, PATHINFO_EXTENSION );
 			$allowed = apply_filters( 'aioseop_allowed_image_extensions', self::$image_extensions );
 			// Bail if image does not refer to an image file otherwise Google Search Console might reject the sitemap.
 			if ( ! in_array( $extn, $allowed, true ) ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4042,6 +4042,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return false;
 			}
 
+			$image   = aiosp_common::absolutize_url( $image );
 			$extn    = pathinfo( $image, PATHINFO_EXTENSION );
 			$allowed = apply_filters( 'aioseop_allowed_image_extensions', self::$image_extensions );
 			// Bail if image does not refer to an image file otherwise Google Search Console might reject the sitemap.


### PR DESCRIPTION
Issue #1614

## Proposed changes

Replace the parse_url() function with the built-in wp_parse_url() function. 

## Types of changes

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Have a look at the code changes and see where this function has been changed. You'll just want to check if everything still works fine, mainly the sitemap.

EDIT: in order to test if schemeless images are still being processed correctly, which is what is_image_url_valid() is meant for, follow these steps:

1. Create three new posts. 

- The first post should have an image tag with an absolute source URL such as "http://example.org/image1.jpg". 
- The second post should have an image tag with a source URL of the following format: "//example.org/image2.jpg".
- The third post should have an image tag with a source URL of the following format: "/image3.jpg".

2. Go to the XML Sitemap and make sure that each of these posts has 1 image in the sitemap.

## Further comments

I checked with Xdebug to make sure that the result is the same for each instance.