### PR TITLE
change boolvar to bool for < php 5.5

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4404,7 +4404,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		// Handle Schema.
-		if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
+		if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
 			$aioseop_schema = new AIOSEOP_Schema_Builder();
 			$aioseop_schema->display_json_ld_head_script();
 		}


### PR DESCRIPTION
Issue #2769 

## Proposed changes

In 3.2, we introduced the boolvar() function, which requires PHP 5.5 or greater. I've replaced it with (bool) which should accomplish the same thing for our purposes.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ x] I've selected the appropriate branch (ie x.y rather than master).
- [ x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions
- In AIOSEOP 3.2, with schema enabled, you should get a fatal error on the front-end when running PHP < 5.5.
- Test that this PR no longer gives a fatal error on the front-end with PHP < 5.5.
- Test that the schema info is output to the front end.

## Further comments

For code review, make sure that this accomplishes the same thing.