### PR TITLE
 Fix illegal string offset in schema graph organization

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4404,7 +4404,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		// Handle Schema.
-		if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
+		if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
 			$aioseop_schema = new AIOSEOP_Schema_Builder();
 			$aioseop_schema->display_json_ld_head_script();
 		}

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -4,7 +4,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for WordPress. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 50 million downloads since 2007.
-Version: 3.2
+Version: 3.2.1
 Author: Michael Torbert
 Author URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Text Domain: all-in-one-seo-pack
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The original WordPress SEO plugin.
  *
  * @package All-in-One-SEO-Pack
- * @version 3.2
+ * @version 3.2.1
  */
 
 if ( ! defined( 'AIOSEOPPRO' ) ) {
@@ -46,7 +46,7 @@ if ( ! defined( 'AIOSEOP_PLUGIN_NAME' ) ) {
 	}
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '3.2' );
+	define( 'AIOSEOP_VERSION', '3.2.1' );
 }
 
 /*

--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -196,7 +196,11 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 
 		// Fallback on Customizer site logo.
 		if ( ! $logo_id ) {
-			$logo_id = get_theme_mod( 'custom_logo' );
+			$customizer_logo = get_theme_mod( 'custom_logo' );
+
+			if ( is_numeric( $customizer_logo ) ) {
+				$logo_id = intval( $customizer_logo );
+			}
 		}
 
 		// Prevent case type errors if empty/false.

--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -105,15 +105,21 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 		$rtn_data = array();
 
 		$logo_id   = $this->get_logo_id();
-		$logo_meta = wp_get_attachment_metadata( $logo_id );
 		if ( ! empty( $logo_id ) ) {
 			$rtn_data = array(
-				'@type'  => 'ImageObject',
-				'@id'    => home_url() . '/#logo',
-				'url'    => wp_get_attachment_image_url( $logo_id, 'full' ),
-				'width'  => $logo_meta['width'],
-				'height' => $logo_meta['height'],
+				'@type' => 'ImageObject',
+				'@id'   => home_url() . '/#logo',
+				'url'   => wp_get_attachment_image_url( $logo_id, 'full' ),
 			);
+
+			$logo_meta = wp_get_attachment_metadata( $logo_id );
+			// Get image dimensions. Some images may not have this property.
+			if ( isset( $rtn_data['width'] ) ) {
+				$rtn_data['width']  = $logo_meta['width'];
+			}
+			if ( isset( $rtn_data['height'] ) ) {
+				$rtn_data['height'] = $logo_meta['height'];
+			}
 
 			$caption = wp_get_attachment_caption( $logo_id );
 			if ( false !== $caption || ! empty( $caption ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hallsofmontezuma, semperplugins, wpsmort, arnaudbroes
 Tags: SEO, Google Search Console, XML Sitemap, meta description, meta title, noindex
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 3.2
+Stable tag: 3.2.1
 License: GPLv2 or later
 Requires PHP: 5.2.4
 


### PR DESCRIPTION
Issue #2766

## Proposed changes

PHP error with an array variable not being set; which was produced by the $logo_id not returning an int image ID.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions

Was not able to reproduce, but I speculate the following...

Requires a custom theme that hooks into the customizer, but uses its own settings. Add the image to the theme settings (not the customizer). Fetching the logo ID does not return a numeric value as expected, and then fetched meta data with a value that is expected to be an attachment ID.

Note: Testing may have to be done on the clone site.

## Further comments

Composer theme by Innwithemes is known to trigger the issue.
