### PR TITLE
Remove using post_content for generating schema description

### DIFF
--- a/inc/schema/graphs/graph-webpage.php
+++ b/inc/schema/graphs/graph-webpage.php
@@ -168,11 +168,6 @@ class AIOSEOP_Graph_WebPage extends AIOSEOP_Graph_Creativework {
 		if ( ! $post_description && ! post_password_required( $post ) ) {
 			if ( ! empty( $post->post_excerpt ) ) {
 				$post_description = $post->post_excerpt;
-			} elseif ( ! empty( $post->post_content ) ) {
-				$post_description = $post->post_content;
-				$post_description = aioseop_do_shortcodes( $post_description );
-				$post_description = strip_shortcodes( $post_description );
-				$post_description = wp_strip_all_tags( $post_description );
 			}
 		}
 


### PR DESCRIPTION
Issue #2785

## Proposed changes

Removes generating schema description from post_content.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)
- Removing old code/functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1) Enable schema markup.
2) Go to a published page, and check if the Schema Description is not generated from the content.

Note: Description used the SEO Description, or if empty, the post Excerpt.
