### PR TITLE
Fix broken Help link for Google Settings

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1005,7 +1005,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			),
 			'google'    => array(
 				'name'      => __( 'Google Settings', 'all-in-one-seo-pack' ),
-				'help_link' => 'https://semperplugins.com/documentation/google-settings/',
+				'help_link' => 'https://semperplugins.com/documentation/advanced-google-analytics-settings/',
 				'options'   => array(
 					'google_analytics_id',
 					'ga_advanced_options',


### PR DESCRIPTION
Issue #2763

## Proposed changes
Fixes a broken Help link for the Google Settings section due to removal of the original documentation page,

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
1. Go to All in One SEO > General Settings > Google Settings and click on the Help link in the top right of the meta box
2. Verify that it opens the correct documentation page (https://semperplugins.com/documentation/advanced-google-analytics-settings/) in a new tab