### PR TITLE
Fix undefined index in (video) sitemap

### DIFF
--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4605,7 +4605,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( 0 === (int) get_option( 'page_on_front' ) ) {
 				return $links;
 			}
-			
+
 			$prio = 'no';
 			$freq = 'no';
 			if ( isset( $this->options['aiosp_sitemap_prio_homepage'] ) ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4605,8 +4605,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( 0 === (int) get_option( 'page_on_front' ) ) {
 				return $links;
 			}
-			$prio = $this->options['aiosp_sitemap_prio_homepage'];
-			$freq = $this->options['aiosp_sitemap_freq_homepage'];
+			
+			$prio = 'no';
+			$freq = 'no';
+			if ( isset( $this->options['aiosp_sitemap_prio_homepage'] ) ) {
+				$prio = $this->options['aiosp_sitemap_prio_homepage'];
+			}
+			if ( isset( $this->options['aiosp_sitemap_freq_homepage'] ) ) {
+				$freq = $this->options['aiosp_sitemap_freq_homepage'];
+			}
 
 			$homepage_url = get_site_url() . '/';
 			$homepage_index = array_search( $homepage_url, array_column( $links, 'loc' ) );


### PR DESCRIPTION
Issue #2796

## Proposed changes

Fix PHP error on video sitemap.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. Set up a new site with a static home page and a static blog page and add a post with a video.
2. Install Pro v3.2.2 and enable the Video Sitemap.
3. View the sitemap and click on the post-video-sitemap.xml, this should trigger the notices.

