### PR TITLE
Fix error with PHP 5.4 missing array_column()

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -447,6 +447,7 @@ if ( ! function_exists( 'aioseop_init_class' ) ) {
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/opengraph.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/abstract/aiosep_compatible.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/compat-init.php' );
+		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/php-functions.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/front.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/google-analytics.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'admin/display/welcome.php' );

--- a/inc/compatability/php-functions.php
+++ b/inc/compatability/php-functions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Compatibility functions for PHP.
+ *
+ * @package All_in_One_SEO_Pack
+ */
+
+if ( ! function_exists( 'array_column' ) ) {
+	/**
+	 * Array Column PHP 5 >= 5.5.0, PHP 7
+	 *
+	 * Return the values from a single column in the input array.
+	 *
+	 * Pre-5.5 replacement/drop-in.
+	 *
+	 * @since 3.2
+	 *
+	 * @param array  $input
+	 * @param string $column_key
+	 * @return array
+	 */
+	function array_column( $input, $column_key ) {
+		return array_combine( array_keys( $input ), wp_list_pluck( $input, $column_key ) );
+	}
+}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4609,8 +4609,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$freq = $this->options['aiosp_sitemap_freq_homepage'];
 
 			$homepage_url   = get_site_url() . '/';
-			$links_locs     = array_combine( array_keys( $links ), wp_list_pluck( $links, 'loc' ) );
-			$homepage_index = array_search( $homepage_url, $links_locs );
+			$homepage_index = array_search( $homepage_url, array_column( $links, 'loc' ) );
 
 			if ( ! $homepage_url ) {
 				return $links;
@@ -4642,8 +4641,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			}
 
 			$shop_page_url   = get_permalink( wc_get_page_id( 'shop' ) );
-			$links_locs      = array_combine( array_keys( $links ), wp_list_pluck( $links, 'loc' ) );
-			$shop_page_index = array_search( $shop_page_url, $links_locs );
+			$shop_page_index = array_search( $shop_page_url, array_column( $links, 'loc' ) );
 
 			if ( ! $shop_page_index ) {
 				return $links;

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4608,8 +4608,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			$prio = $this->options['aiosp_sitemap_prio_homepage'];
 			$freq = $this->options['aiosp_sitemap_freq_homepage'];
 
-			$homepage_url = get_site_url() . '/';
-			$homepage_index = array_search( $homepage_url, array_column( $links, 'loc' ) );
+			$homepage_url   = get_site_url() . '/';
+			$links_locs     = array_combine( array_keys( $links ), wp_list_pluck( $links, 'loc' ) );
+			$homepage_index = array_search( $homepage_url, $links_locs );
 
 			if ( ! $homepage_url ) {
 				return $links;
@@ -4640,8 +4641,9 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return $links;
 			}
 
-			$shop_page_url = get_permalink( wc_get_page_id( 'shop' ) );
-			$shop_page_index = array_search( $shop_page_url, array_column( $links, 'loc' ) );
+			$shop_page_url   = get_permalink( wc_get_page_id( 'shop' ) );
+			$links_locs      = array_combine( array_keys( $links ), wp_list_pluck( $links, 'loc' ) );
+			$shop_page_index = array_search( $shop_page_url, $links_locs );
 
 			if ( ! $shop_page_index ) {
 				return $links;


### PR DESCRIPTION
Issue #2799

## Proposed changes

Fix php 5.4 error with array_column missing.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I've selected the appropriate branch (ie x.y rather than master).
- [ ] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. Install and have PHP 5.4 active.
2. Have AIOSEOP running in pro.
3. Have the Video Sitemap active and have a post with a youtube video.
4. Go to Video Sitemap.
5. Click on `post-video-sitemap.xml`

There should be no PHP error with array_column()
