### PR TITLE
Bugfix/avoid php notice

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -5698,7 +5698,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 */
 	function check_recently_activated_modules() {
 		global $aioseop_options;
-		$options = get_option( 'aioseop_options' );
+		$options = get_option( 'aioseop_options', array() );
 		$modules_before = array();
 		$modules_now    = array();
 		if ( array_key_exists( 'modules', $aioseop_options ) && array_key_exists( 'aiosp_feature_manager_options', $aioseop_options['modules'] ) ) {

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -447,6 +447,7 @@ if ( ! function_exists( 'aioseop_init_class' ) ) {
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/opengraph.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/abstract/aiosep_compatible.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/compat-init.php' );
+		require_once( AIOSEOP_PLUGIN_DIR . 'inc/compatability/php-functions.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/front.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'public/google-analytics.php' );
 		require_once( AIOSEOP_PLUGIN_DIR . 'admin/display/welcome.php' );

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-Plugin Name: All In One SEO Pack
+Plugin Name: All In One SEO Pack Pro
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for WordPress. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 50 million downloads since 2007.
 Version: 3.2.3

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-Plugin Name: All In One SEO Pack Pro
+Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for WordPress. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 50 million downloads since 2007.
 Version: 3.2.3

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -4,7 +4,7 @@
 Plugin Name: All In One SEO Pack
 Plugin URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Description: Out-of-the-box SEO for WordPress. Features like XML Sitemaps, SEO for custom post types, SEO for blogs or business sites, SEO for ecommerce sites, and much more. More than 50 million downloads since 2007.
-Version: 3.2.2
+Version: 3.2.3
 Author: Michael Torbert
 Author URI: https://semperplugins.com/all-in-one-seo-pack-pro-version/
 Text Domain: all-in-one-seo-pack
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * The original WordPress SEO plugin.
  *
  * @package All-in-One-SEO-Pack
- * @version 3.2.2
+ * @version 3.2.3
  */
 
 if ( ! defined( 'AIOSEOPPRO' ) ) {
@@ -46,7 +46,7 @@ if ( ! defined( 'AIOSEOP_PLUGIN_NAME' ) ) {
 	}
 }
 if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '3.2.2' );
+	define( 'AIOSEOP_VERSION', '3.2.3' );
 }
 
 /*

--- a/inc/compatability/php-functions.php
+++ b/inc/compatability/php-functions.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Compatibility functions for PHP.
+ *
+ * @package All_in_One_SEO_Pack
+ */
+
+if ( ! function_exists( 'array_column' ) ) {
+	/**
+	 * Array Column PHP 5 >= 5.5.0, PHP 7
+	 *
+	 * Return the values from a single column in the input array.
+	 *
+	 * Pre-5.5 replacement/drop-in.
+	 *
+	 * @since 3.2
+	 *
+	 * @param array  $input
+	 * @param string $column_key
+	 * @return array
+	 */
+	function array_column( $input, $column_key ) {
+		return array_combine( array_keys( $input ), wp_list_pluck( $input, $column_key ) );
+	}
+}

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4615,7 +4615,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				$freq = $this->options['aiosp_sitemap_freq_homepage'];
 			}
 
-			$homepage_url = get_site_url() . '/';
+			$homepage_url   = get_site_url() . '/';
 			$homepage_index = array_search( $homepage_url, array_column( $links, 'loc' ) );
 
 			if ( ! $homepage_url ) {
@@ -4647,7 +4647,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 				return $links;
 			}
 
-			$shop_page_url = get_permalink( wc_get_page_id( 'shop' ) );
+			$shop_page_url   = get_permalink( wc_get_page_id( 'shop' ) );
 			$shop_page_index = array_search( $shop_page_url, array_column( $links, 'loc' ) );
 
 			if ( ! $shop_page_index ) {

--- a/modules/aioseop_sitemap.php
+++ b/modules/aioseop_sitemap.php
@@ -4605,8 +4605,15 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Sitemap' ) ) {
 			if ( 0 === (int) get_option( 'page_on_front' ) ) {
 				return $links;
 			}
-			$prio = $this->options['aiosp_sitemap_prio_homepage'];
-			$freq = $this->options['aiosp_sitemap_freq_homepage'];
+
+			$prio = 'no';
+			$freq = 'no';
+			if ( isset( $this->options['aiosp_sitemap_prio_homepage'] ) ) {
+				$prio = $this->options['aiosp_sitemap_prio_homepage'];
+			}
+			if ( isset( $this->options['aiosp_sitemap_freq_homepage'] ) ) {
+				$freq = $this->options['aiosp_sitemap_freq_homepage'];
+			}
 
 			$homepage_url = get_site_url() . '/';
 			$homepage_index = array_search( $homepage_url, array_column( $links, 'loc' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: hallsofmontezuma, semperplugins, wpsmort, arnaudbroes
 Tags: SEO, Google Search Console, XML Sitemap, meta description, meta title, noindex
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 3.2.2
+Stable tag: 3.2.3
 License: GPLv2 or later
 Requires PHP: 5.2.4
 


### PR DESCRIPTION
See #2805.

Issue #

## Proposed changes

See #2805 

## Steps to reproduce

I can't figure out reliable steps to reproduce. If the option is totally absent, then the schema update routines in `AIOSEOP_Updates` will reinstall the options before the 'shutdown' hook is fired.

My guess is that there's a race condition here, of the following form:
1. The plugin options are unsaved
2. Two AJAX requests are triggered at roughly the same time. These AJAX requests come from the front end, but go to wp-admin/admin-ajax.php, so `is_admin()` is true (and your 'shutdown' callback is fired).
3. The first of these requests triggers the 'version_updates' routine, but it doesn't have a chance to save the options to the database before the second request reaches the 'shutdown' hook. Thus, the `get_option()` call in that second request turns up nothing.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Don't assume the tester knows the entire backstory of the issue, and don't force him/her to decipher the code to try and figure out what -it's doing or how to test it.
- Do provide step by step instructions on how to test. 
- Do note things to watch out for.
- Do note what aspects the tester should try and break.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
