### PR TITLE
Fix error undefined constant JSON_UNESCAPED_SLASHES

### DIFF
--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -72,7 +72,11 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 			}
 		} else {
 			// Get Name from General > Schema Settings > Organization Name, and fallback on WP's Site Name.
-			$rtn_data['name']   = $aioseop_options['aiosp_schema_organization_name'] ?: get_bloginfo( 'name' );
+			if ( $aioseop_options['aiosp_schema_organization_name'] ){
+				$rtn_data['name']   = $aioseop_options['aiosp_schema_organization_name'];
+			}else{
+				$rtn_data['name']   = get_bloginfo( 'name' );
+			}
 			$rtn_data['sameAs'] = $this->get_site_social_profile_links();
 
 			// Handle Logo/Image.

--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -72,10 +72,10 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 			}
 		} else {
 			// Get Name from General > Schema Settings > Organization Name, and fallback on WP's Site Name.
-			if ( $aioseop_options['aiosp_schema_organization_name'] ){
-				$rtn_data['name']   = $aioseop_options['aiosp_schema_organization_name'];
-			}else{
-				$rtn_data['name']   = get_bloginfo( 'name' );
+			if ( $aioseop_options['aiosp_schema_organization_name'] ) {
+				$rtn_data['name'] = $aioseop_options['aiosp_schema_organization_name'];
+			} else {
+				$rtn_data['name'] = get_bloginfo( 'name' );
 			}
 			$rtn_data['sameAs'] = $this->get_site_social_profile_links();
 

--- a/inc/schema/graphs/graph.php
+++ b/inc/schema/graphs/graph.php
@@ -159,7 +159,7 @@ abstract class AIOSEOP_Graph {
 			$schema_data = str_replace( '\/', '/', $schema_data );
 		}
 		// If json encode returned false, set as empty string.
-		if ( ! $schema_data ){
+		if ( ! $schema_data ) {
 			$schema_data = '';
 		}
 

--- a/inc/schema/graphs/graph.php
+++ b/inc/schema/graphs/graph.php
@@ -149,7 +149,19 @@ abstract class AIOSEOP_Graph {
 		 * @param array  Dynamically generated data through inherited schema graphs.
 		 */
 		$schema_data = apply_filters( 'aioseop_schema_class_data_' . get_class( $this ), $this->prepare() );
-		return wp_json_encode( (object) $schema_data, JSON_UNESCAPED_SLASHES ) ?: '';
+
+		// Encode to json string, and remove string type around shortcodes.
+		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
+			$schema_data = wp_json_encode( (object) $schema_data, JSON_UNESCAPED_SLASHES );
+		} else {
+			// PHP <= 5.3 compatibility.
+			$schema_data = wp_json_encode( (object) $schema_data );
+			$schema_data = str_replace( '\/', '/', $schema_data );
+		}
+		// If json encode returned false, set as empty string.
+		$schema_data = $schema_data ?: '';
+
+		return $schema_data;
 	}
 
 	/**

--- a/inc/schema/graphs/graph.php
+++ b/inc/schema/graphs/graph.php
@@ -159,7 +159,9 @@ abstract class AIOSEOP_Graph {
 			$schema_data = str_replace( '\/', '/', $schema_data );
 		}
 		// If json encode returned false, set as empty string.
-		$schema_data = $schema_data ?: '';
+		if ( ! $schema_data ){
+			$schema_data = '';
+		}
 
 		return $schema_data;
 	}

--- a/inc/schema/schema-builder.php
+++ b/inc/schema/schema-builder.php
@@ -157,7 +157,16 @@ class AIOSEOP_Schema_Builder {
 		$layout = apply_filters( 'aioseop_schema_layout', $layout );
 
 		// Encode to json string, and remove string type around shortcodes.
-		$layout = wp_json_encode( (object) $layout, JSON_UNESCAPED_SLASHES );
+		if ( version_compare( PHP_VERSION, '5.4', '>=' ) ) {
+			$layout = wp_json_encode( (object) $layout, JSON_UNESCAPED_SLASHES );
+		} else {
+			// PHP <= 5.3 compatibility.
+			$layout = wp_json_encode( (object) $layout );
+			$layout = str_replace( '\/', '/', $layout );
+		}
+		// If json encode returned false, set as empty string.
+		$schema_data = $layout ?: '';
+
 		$layout = str_replace( '"[', '[', $layout );
 		$layout = str_replace( ']"', ']', $layout );
 

--- a/inc/schema/schema-builder.php
+++ b/inc/schema/schema-builder.php
@@ -164,8 +164,6 @@ class AIOSEOP_Schema_Builder {
 			$layout = wp_json_encode( (object) $layout );
 			$layout = str_replace( '\/', '/', $layout );
 		}
-		// If json encode returned false, set as empty string.
-		$schema_data = $layout ?: '';
 
 		$layout = str_replace( '"[', '[', $layout );
 		$layout = str_replace( ']"', ']', $layout );


### PR DESCRIPTION
Issue #2837

## Proposed changes

Fixes a PHP <= 5.3 error with JSON_UNESCAPED_SLASHES missing until PHP 5.4.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I've selected the appropriate branch (ie x.y rather than master).
- [ ] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- PHP 5.3
- MySQL 5.6.45
- WP 5.1.1

1) Go to AIOSEOP General settings and enable Schema Markup.
2) Go to front page.

Bug: Displays a PHP notice Undefined constant JSON_UNESCAPED_SLASHES.
Expected: No error should be produced.

