### PR TITLE
Include Google Analytics on pages not checked in General Settings

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3867,14 +3867,14 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			add_filter( 'wp_title', array( $this, 'wp_title' ), 20 );
 		}
 	}
-
-/**
+	
+	/**
 	 * The is_page_included() function.
 	 *
 	 * Checks whether All in One SEO Pack is enabled for this page.
 	 *
 	 * @since ?
-     * @since 3.3 Show Google Analytics if post type isn't checked in options.
+	 * @since 3.3 Show Google Analytics if post type isn't checked in options.
 	 *
 	 * @return bool
 	 */
@@ -4200,13 +4200,13 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		return empty( $post_type ) || in_array( get_post_type(), $aioseop_options['aiosp_cpostactive'], true );
 	}
 
-		/**
-     * Checks to see if Google Analytics should be excluded from the current page.
-     *
-     * Looks at both the individual post settings and the General Settings.
-     *
-     * @since 3.3
-     *
+	/**
+	 * Checks to see if Google Analytics should be excluded from the current page.
+	 *
+	 * Looks at both the individual post settings and the General Settings.
+	 *
+	 * @since 3.3.0
+	 *
 	 * @return bool
 	 */
 	function analytics_excluded(){
@@ -4218,8 +4218,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		if ( $aiosp_disable_analytics || ! aioseop_option_isset( 'aiosp_google_analytics_id' ) ) {
 		    return true;
-			}
-			return false;
+		}
+		return false;
 	}
 
 	/**
@@ -4261,8 +4261,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			}
 
 			if ( ! $this->analytics_excluded() ) {
-					remove_action( 'aioseop_modules_wp_head', array( $this, 'aiosp_google_analytics' ) );
-					add_action( 'wp_head', array( $this, 'aiosp_google_analytics' ) );
+				remove_action( 'aioseop_modules_wp_head', array( $this, 'aiosp_google_analytics' ) );
+				add_action( 'wp_head', array( $this, 'aiosp_google_analytics' ) );
 			}
 
 			return;

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4209,7 +4209,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 *
 	 * @return bool
 	 */
-	function analytics_excluded(){
+	function analytics_excluded() {
 		$aiosp_disable_analytics = false;
 
 		if ( isset( $this->meta_opts['aiosp_disable_analytics'] ) ) {
@@ -4217,7 +4217,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		if ( $aiosp_disable_analytics || ! aioseop_option_isset( 'aiosp_google_analytics_id' ) ) {
-		    return true;
+			return true;
 		}
 		return false;
 	}

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3868,12 +3868,13 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 	}
 
-	/**
+/**
 	 * The is_page_included() function.
 	 *
 	 * Checks whether All in One SEO Pack is enabled for this page.
 	 *
 	 * @since ?
+     * @since 3.3 Show Google Analytics if post type isn't checked in options.
 	 *
 	 * @return bool
 	 */
@@ -3923,28 +3924,17 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 		$this->meta_opts = $this->get_current_options( array(), 'aiosp' );
 
-		$aiosp_disable           = false;
-		$aiosp_disable_analytics = false;
+		$aiosp_disable = false;
 
 		if ( ! empty( $this->meta_opts ) ) {
 			if ( isset( $this->meta_opts['aiosp_disable'] ) ) {
 				$aiosp_disable = $this->meta_opts['aiosp_disable'];
-			}
-			if ( isset( $this->meta_opts['aiosp_disable_analytics'] ) ) {
-				$aiosp_disable_analytics = $this->meta_opts['aiosp_disable_analytics'];
 			}
 		}
 
 		$aiosp_disable = apply_filters( 'aiosp_disable', $aiosp_disable ); // API filter to disable AIOSEOP.
 
 		if ( $aiosp_disable ) {
-			if ( ! $aiosp_disable_analytics ) {
-				if ( aioseop_option_isset( 'aiosp_google_analytics_id' ) ) {
-					remove_action( 'aioseop_modules_wp_head', array( $this, 'aiosp_google_analytics' ) );
-					add_action( 'wp_head', array( $this, 'aiosp_google_analytics' ) );
-				}
-			}
-
 			return false;
 		}
 
@@ -4210,6 +4200,28 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		return empty( $post_type ) || in_array( get_post_type(), $aioseop_options['aiosp_cpostactive'], true );
 	}
 
+		/**
+     * Checks to see if Google Analytics should be excluded from the current page.
+     *
+     * Looks at both the individual post settings and the General Settings.
+     *
+     * @since 3.3
+     *
+	 * @return bool
+	 */
+	function analytics_excluded(){
+		$aiosp_disable_analytics = false;
+
+		if ( isset( $this->meta_opts['aiosp_disable_analytics'] ) ) {
+			$aiosp_disable_analytics = $this->meta_opts['aiosp_disable_analytics'];
+		}
+
+		if ( $aiosp_disable_analytics || ! aioseop_option_isset( 'aiosp_google_analytics_id' ) ) {
+		    return true;
+			}
+			return false;
+	}
+
 	/**
 	 * WP Head
 	 *
@@ -4226,7 +4238,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		if ( ! $this->is_page_included() ) {
-
 			/**
 			 * The aioseop_robots_meta filter hook.
 			 *
@@ -4239,7 +4250,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			 * @return string
 			 */
 			$robots_meta = apply_filters( 'aioseop_robots_meta', $this->get_robots_meta() );
-
 			if ( ! empty( $robots_meta ) && 'index,follow' !== $robots_meta ) {
 				printf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " >\n";
 			}
@@ -4248,6 +4258,11 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				// Change the query back after we've finished.
 				$GLOBALS['wp_query'] = $old_wp_query;
 				unset( $old_wp_query );
+			}
+
+			if ( ! $this->analytics_excluded() ) {
+					remove_action( 'aioseop_modules_wp_head', array( $this, 'aiosp_google_analytics' ) );
+					add_action( 'wp_head', array( $this, 'aiosp_google_analytics' ) );
 			}
 
 			return;

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -3867,7 +3867,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			add_filter( 'wp_title', array( $this, 'wp_title' ), 20 );
 		}
 	}
-	
+
 	/**
 	 * The is_page_included() function.
 	 *
@@ -4210,6 +4210,9 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 	 * @return bool
 	 */
 	function analytics_excluded() {
+
+		$this->meta_opts = $this->get_current_options( array(), 'aiosp' ); // Get page-specific options.
+
 		$aiosp_disable_analytics = false;
 
 		if ( isset( $this->meta_opts['aiosp_disable_analytics'] ) ) {


### PR DESCRIPTION
Issue #2651 

## Proposed changes

Include Google Analytics on pages not checked in General Settings #2651. To do this, I've moved the code into our own wp_head so that it fires at the right time.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- Verify the bug in #2658, in that GA doesn't show up if SEO for that post type is disabled.
- Verify that GA now shows up if the post type is disabled.
- Also check that it's removed if "disable GA on this post" is selected.

