### PR TITLE
Update ogp.me link to HTTPS

### DIFF
--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1054,7 +1054,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			$attributes = apply_filters(
 				$this->prefix . 'attributes',
 				array(
-					'prefix="og: http://ogp.me/ns#"',
+					'prefix="og: https://ogp.me/ns#"',
 				)
 			);
 


### PR DESCRIPTION
Issue #2328

## Proposed changes
This changes the link for ogp.me in the HEAD to HTTPS.

## Types of changes
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Activate the Social Meta module and enable Use Schema.org Markup under Schema Settings
- Check the source code of the homepage and/or and page on your site and look for the link in the HEAD
- Verify that disabling Use Schema.org Markup or deactivating the Social Meta module removes the link 