### PR TITLE
Change section title Google Analytics

### DIFF
--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -401,7 +401,7 @@ class AIOSEOP_Helper {
 			'aiosp_yandex_verify'               => __( 'Enter your verification code here to verify your site with Yandex Webmaster Tools.', 'all-in-one-seo-pack' ),
 			'aiosp_baidu_verify'                => __( 'Enter your verification code here to verify your site with Baidu Webmaster Tools.', 'all-in-one-seo-pack' ),
 
-			// Google Settings.
+			// Google Analytics.
 
 			'aiosp_google_analytics_id'         => __( 'Enter your Google Analytics ID here to track visitor behavior on your site using Google Analytics.', 'all-in-one-seo-pack' ),
 			'aiosp_ga_advanced_options'         => __( 'Check to use advanced Google Analytics options.', 'all-in-one-seo-pack' ),
@@ -552,7 +552,7 @@ class AIOSEOP_Helper {
 			'aiosp_yandex_verify'               => 'https://semperplugins.com/documentation/yandex-webmaster-verification/',
 			'aiosp_baidu_verify'                => 'https://semperplugins.com/documentation/baidu-webmaster-verification/',
 
-			// Google Settings.
+			// Google Analytics.
 			'aiosp_google_analytics_id'         => 'https://semperplugins.com/documentation/setting-up-google-analytics/',
 			'aiosp_ga_advanced_options'         => 'https://semperplugins.com/documentation/advanced-google-analytics-settings/',
 			'aiosp_ga_domain'                   => 'https://semperplugins.com/documentation/advanced-google-analytics-settings/#tracking-domain',

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1004,7 +1004,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				'options'   => array( 'google_verify', 'bing_verify', 'pinterest_verify', 'yandex_verify', 'baidu_verify' ),
 			),
 			'google'    => array(
-				'name'      => __( 'Google Settings', 'all-in-one-seo-pack' ),
+				'name'      => __( 'Google Analytics', 'all-in-one-seo-pack' ),
 				'help_link' => 'https://semperplugins.com/documentation/advanced-google-analytics-settings/',
 				'options'   => array(
 					'google_analytics_id',


### PR DESCRIPTION
Issue #2762

## Proposed changes
This changes the section title from Google Settings to Google Analytics as this section only contains Google Analytics settings now.

## Types of changes
- Improves existing code (UI)

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [x] I have created an issue for docs (#2843).

## Testing instructions
Go to All in One SEO > General Settings and verify that the section title is now Google Analytics
