### PR TITLE
Fix version_updates not occuring on frontend

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -481,7 +481,8 @@ if ( ! function_exists( 'aioseop_init_class' ) ) {
 		}
 
 		add_action( 'init', array( $aiosp, 'add_hooks' ) );
-		add_action( 'admin_init', array( $aioseop_updates, 'version_updates' ), 11 );
+		add_action( 'plugins_loaded', array( $aioseop_updates, 'version_updates' ), 11 );
+
 
 		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 		// add_action( 'admin_init', 'aioseop_review_plugin_notice' );

--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -145,8 +145,10 @@ class AIOSEOP_Updates {
 			$this->reset_flush_rewrite_rules_201906();
 		}
 
+		// Cause the update to occur again for 3.2.6.
 		if (
-				version_compare( $old_version, '3.2', '<' )
+				version_compare( $old_version, '3.2', '<' ) ||
+				version_compare( $old_version, '3.2.6', '<' )
 		) {
 			$this->update_schema_markup();
 		}

--- a/inc/aioseop_updates_class.php
+++ b/inc/aioseop_updates_class.php
@@ -150,7 +150,7 @@ class AIOSEOP_Updates {
 				version_compare( $old_version, '3.2', '<' ) ||
 				version_compare( $old_version, '3.2.6', '<' )
 		) {
-			$this->update_schema_markup();
+			$this->update_schema_markup_201907();
 		}
 	}
 
@@ -369,7 +369,7 @@ class AIOSEOP_Updates {
 	 *
 	 * @since 3.2
 	 */
-	public function update_schema_markup() {
+	public function update_schema_markup_201907() {
 		global $aiosp;
 		global $aioseop_options;
 


### PR DESCRIPTION
Issue #2854

## Proposed changes

Fixes AIOSEOP's version_updates function not executing from front end of sites.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
1. Set up a site with a static homepage
2. Git checkout to version 3.1.1.
3. Go to phpMyAdmin, select the site's database, in wp_options, delete aioseop_options.
4. Go to WP Admin in order to initialize AIOSEOP's database options.
5. Go to front end, and close all tabs displaying the WP Admin. (This prevents the WP Heartbeat on the admin side.)
6. Git checkout to version 3.2.4.
7. Refresh tab with front end displayed.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
