### PR TITLE
Enable Schema by default

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -596,7 +596,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				/* translators: This is a setting that outputs basic Schema.org markup, also known as structured data, into the source code of each page. */
 				'name'            => __( 'Use Schema.org Markup', 'all-in-one-seo-pack' ),
 				'type'            => 'radio',
-				'default'         => 0,
+				'default'         => 1,
 				'initial_options' => array(
 					1 => __( 'Enabled', 'all-in-one-seo-pack' ),
 					0 => __( 'Disabled', 'all-in-one-seo-pack' ),


### PR DESCRIPTION
Issue #2868

## Proposed changes
This changes the default setting for Use Schema.org Markup to Enabled. This only affects new installs.

## Types of changes
- Improves existing functionality
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
- Install this on a fresh site and confirm that the Use Schema option is enabled by default
- Install this on an existing site and reset the General Settings to default and confirm that the Use Schema option is enabled by default
- Install this on an existing site with the current live version and where Use Schema is disabled, confirm that the option is not changed
