### PR TITLE
Adds og:video:secure_url tag

### DIFF
--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1548,9 +1548,12 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			);
 
 			// Issue #1848 ( https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/1848 ).
+			// Issue #2867 ( https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/2867 ).
 			if ( is_ssl() ) {
 				$meta['facebook'] += array( 'thumbnail_1' => 'og:image:secure_url' );
 				$thumbnail_1       = $thumbnail;
+				$meta['facebook'] += array( 'video_1' => 'og:video:secure_url' );
+				$video_1 = $video;
 			}
 
 			$tags = array(


### PR DESCRIPTION
Issue #2867

## Proposed changes
This adds the og:video:secure_url tag when SSL is enabled on a site. 

## Types of changes
- Improves existing functionality
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [x] I have created an issue for docs (#2872).

## Testing instructions
- On a site that is not running SSL, create a post and on the Social Settings tab enter a video URL in the Custom Video field
- Check the page source to confirm that only the og:video tag is present
- Change the site to run SSL and check the page source and confirm that both the og:video and og:video:secure_url tags are present and show the same URL