### PR TITLE
Add closing tag to robots meta

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4216,7 +4216,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$robots_meta = apply_filters( 'aioseop_robots_meta', $this->get_robots_meta() );
 
 			if ( ! empty( $robots_meta ) && 'index,follow' !== $robots_meta ) {
-				printf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " />\n";
+				echo sprintf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " />\n";
 			}
 
 			if ( ! empty( $old_wp_query ) ) {

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4216,7 +4216,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			$robots_meta = apply_filters( 'aioseop_robots_meta', $this->get_robots_meta() );
 
 			if ( ! empty( $robots_meta ) && 'index,follow' !== $robots_meta ) {
-				printf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " >\n";
+				printf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " />\n";
 			}
 
 			if ( ! empty( $old_wp_query ) ) {


### PR DESCRIPTION
Issue #2876 

## Proposed changes

We're missing the closing tag after the robots meta.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Create a post.
- On the edit post screen, check "Disable on this page/post"
- On the edit post screen, check NOINDEX and/or NOFOLLOW.
- Verify that you see the robots meta tag without the closing tag in the source code of the post.
- Apply the fix.
- Verify it fixes it.

## Further comments

As described in https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/2876#issuecomment-528972928 we inadvertently removed the closing tag in our robots meta. 
It's important to note that we have two places in the code where the robots meta tag could be generated. This affects the less likely one, so when testing, make sure you've first reproduced the problem on the page where you're testing the fix.
