### PR TITLE
Make bool ready for php upgrade

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4453,10 +4453,17 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			echo "$meta_string\n";
 		}
 
-		// Handle Schema.
-		if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
-			$aioseop_schema = new AIOSEOP_Schema_Builder();
-			$aioseop_schema->display_json_ld_head_script();
+		// Handle Schema. 
+		if ( version_compare( PHP_VERSION, '5.5', '>=' ) ) {
+			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
+				$aioseop_schema = new AIOSEOP_Schema_Builder();
+				$aioseop_schema->display_json_ld_head_script();
+			}
+		}else{
+			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
+				$aioseop_schema = new AIOSEOP_Schema_Builder();
+				$aioseop_schema->display_json_ld_head_script();
+			}	
 		}
 
 		// Handle canonical links.

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4453,17 +4453,17 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			echo "$meta_string\n";
 		}
 
-		// Handle Schema. 
+		// Handle Schema.
 		if ( version_compare( PHP_VERSION, '5.5', '>=' ) ) {
 			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
 				$aioseop_schema = new AIOSEOP_Schema_Builder();
 				$aioseop_schema->display_json_ld_head_script();
 			}
-		}else{
+		} else {
 			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
 				$aioseop_schema = new AIOSEOP_Schema_Builder();
 				$aioseop_schema->display_json_ld_head_script();
-			}	
+			}
 		}
 
 		// Handle canonical links.


### PR DESCRIPTION
Issue #2863

## Proposed changes

This uses both the pre and post PHP 5.5 bool/boolvar(), and makes it easy to find for when we drop support for older versions of PHP.

## Types of changes

What types of changes does your code introduce?

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions
- Make sure schema shows up when checked and doesn't when unchecked. 