### PR TITLE
Add filter hook to disable schema.org markup

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4460,8 +4460,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		 *
 		 * @since 3.2.8
 		 *
-		 * @param string
-		 * @return string
+		 * @return boolean
 		 */
 		if ( apply_filters( 'aioseop_disable_schema', '__return_true' ) ) {
 			// Handle Schema.

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4453,16 +4453,28 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			echo "$meta_string\n";
 		}
 
-		// Handle Schema.
-		if ( version_compare( PHP_VERSION, '5.5', '>=' ) ) {
-			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
-				$aioseop_schema = new AIOSEOP_Schema_Builder();
-				$aioseop_schema->display_json_ld_head_script();
-			}
-		} else {
-			if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
-				$aioseop_schema = new AIOSEOP_Schema_Builder();
-				$aioseop_schema->display_json_ld_head_script();
+		/**
+		 * aioseop_disable_schema filter hook.
+		 *
+		 * Used to disable schema.org output programatically.
+		 *
+		 * @since 3.2.8
+		 *
+		 * @param string
+		 * @return string
+		 */
+		if ( apply_filters( 'aioseop_disable_schema', '__return_true' ) ) {
+			// Handle Schema.
+			if ( version_compare( PHP_VERSION, '5.5', '>=' ) ) {
+				if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {
+					$aioseop_schema = new AIOSEOP_Schema_Builder();
+					$aioseop_schema->display_json_ld_head_script();
+				}
+			} else {
+				if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && (bool) $aioseop_options['aiosp_schema_markup'] ) {
+					$aioseop_schema = new AIOSEOP_Schema_Builder();
+					$aioseop_schema->display_json_ld_head_script();
+				}
 			}
 		}
 

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4454,7 +4454,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		/**
-		 * aioseop_disable_schema filter hook.
+		 * The aioseop_disable_schema filter hook.
 		 *
 		 * Used to disable schema.org output programatically.
 		 *

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4462,7 +4462,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		 *
 		 * @return boolean
 		 */
-		if ( apply_filters( 'aioseop_disable_schema', '__return_true' ) ) {
+		if ( ! apply_filters( 'aioseop_disable_schema', false ) ) {
 			// Handle Schema.
 			if ( version_compare( PHP_VERSION, '5.5', '>=' ) ) {
 				if ( ! empty( $aioseop_options['aiosp_schema_markup'] ) && boolval( $aioseop_options['aiosp_schema_markup'] ) ) {


### PR DESCRIPTION
Issue #2913

## Proposed changes

Adds an API filter hook to programmatically disable our schema.org markup.

## Types of changes

What types of changes does your code introduce?

- Adds new API hooks

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- By default this conditional is true. If you do nothing, our schema markup should be outputted as normal.
- Returning false should cause schema to not load. (You can either make a callback function or just use __return_false.) 
- Feel free to get fancy with it, and only add the filter for certain post types, a certain post, etc.
- Our schema output should still load anywhere else on the site, not specified in the above step.