### PR TITLE
Change schema person's name & logo to add the option of manually ente…

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -664,7 +664,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				),
 				// Add initial options below.
 			),
-			'schema_person_manual_name' => array(
+			'schema_person_manual_name'   => array(
 				/* translators: Option shown when 'Manually Enter' is selected in Person's Username. Users use this to enter the Person's name for schema Person. */
 				'name'     => __( 'Person\'s Name', 'all-in-one-seo-pack' ),
 				'type'     => 'text',
@@ -674,7 +674,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 					'aiosp_schema_person_user'     => '-1',
 				),
 			),
-			'schema_person_manual_image' => array(
+			'schema_person_manual_image'  => array(
 				/* translators: Option shown when 'Manually Enter' is selected in Person's Username. Users use this to enter the Person's image for schema Person. */
 				'name'     => __( 'Person\'s Image', 'all-in-one-seo-pack' ),
 				'type'     => 'image',

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -664,6 +664,26 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 				),
 				// Add initial options below.
 			),
+			'schema_person_manual_name' => array(
+				/* translators: Option shown when 'Manually Enter' is selected in Person's Username. Users use this to enter the Person's name for schema Person. */
+				'name'     => __( 'Person\'s Name', 'all-in-one-seo-pack' ),
+				'type'     => 'text',
+				'condshow' => array(
+					'aiosp_schema_markup'          => 1,
+					'aiosp_schema_site_represents' => 'person',
+					'aiosp_schema_person_user'     => '-1',
+				),
+			),
+			'schema_person_manual_image' => array(
+				/* translators: Option shown when 'Manually Enter' is selected in Person's Username. Users use this to enter the Person's image for schema Person. */
+				'name'     => __( 'Person\'s Image', 'all-in-one-seo-pack' ),
+				'type'     => 'image',
+				'condshow' => array(
+					'aiosp_schema_markup'          => 1,
+					'aiosp_schema_site_represents' => 'person',
+					'aiosp_schema_person_user'     => '-1',
+				),
+			),
 			'schema_phone_number'         => array(
 				/* translators: This is a setting where users can enter a phone number for their organization. This is used for our schema.org markup. */
 				'name'         => __( 'Phone Number', 'all-in-one-seo-pack' ),
@@ -1043,6 +1063,8 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 					'schema_organization_name',
 					'schema_organization_logo',
 					'schema_person_user',
+					'schema_person_manual_name',
+					'schema_person_manual_image',
 					'schema_phone_number',
 					'schema_contact_type',
 				),
@@ -1104,7 +1126,11 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		);
 		$users     = get_users( $user_args );
 
-		$this->default_options['schema_person_user']['initial_options'] = array();
+		// Person's Username setting.
+		$this->default_options['schema_person_user']['initial_options'] = array(
+			0  => __( '- Select -', 'all-in-one-seo-pack' ),
+			-1 => __( 'Manually Enter', 'all-in-one-seo-pack' ),
+		);
 		foreach ( $users as $user ) {
 			$this->default_options['schema_person_user']['initial_options'][ $user->ID ] = $user->data->user_nicename . ' (' . $user->data->display_name . ')';
 		}

--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -60,8 +60,8 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 			$person_id = intval( $aioseop_options['aiosp_schema_person_user'] );
 			// If no user is selected, then use first admin available.
 			if ( 0 === $person_id ) {
-				$args = array(
-					'role' => 'administrator'
+				$args  = array(
+					'role' => 'administrator',
 				);
 				$users = get_users( $args );
 
@@ -70,8 +70,8 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 				}
 			}
 
-			$rtn_data['@type']  = array( 'Person', $this->slug );
-			$rtn_data['@id']    = home_url() . '/#person';
+			$rtn_data['@type'] = array( 'Person', $this->slug );
+			$rtn_data['@id']   = home_url() . '/#person';
 
 			if ( -1 === $person_id ) {
 				// Manually added Person's name.
@@ -86,7 +86,7 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 				}
 			} else {
 				// User's Display Name.
-				$rtn_data['name']   = get_the_author_meta( 'display_name', $person_id );
+				$rtn_data['name'] = get_the_author_meta( 'display_name', $person_id );
 
 				// Social links from user profile.
 				$rtn_data['sameAs'] = $this->get_user_social_profile_links( $person_id );

--- a/inc/schema/graphs/graph-organization.php
+++ b/inc/schema/graphs/graph-organization.php
@@ -58,17 +58,45 @@ class AIOSEOP_Graph_Organization extends AIOSEOP_Graph {
 		// Site represents Organization or Person.
 		if ( 'person' === $aioseop_options['aiosp_schema_site_represents'] ) {
 			$person_id = intval( $aioseop_options['aiosp_schema_person_user'] );
+			// If no user is selected, then use first admin available.
+			if ( 0 === $person_id ) {
+				$args = array(
+					'role' => 'administrator'
+				);
+				$users = get_users( $args );
+
+				if ( ! empty( $users ) ) {
+					$person_id = $users[0]->ID;
+				}
+			}
 
 			$rtn_data['@type']  = array( 'Person', $this->slug );
 			$rtn_data['@id']    = home_url() . '/#person';
-			$rtn_data['name']   = get_the_author_meta( 'display_name', $person_id );
-			$rtn_data['sameAs'] = $this->get_user_social_profile_links( $person_id );
 
-			// Handle Logo/Image.
-			$image_schema = $this->prepare_image( $this->get_user_image_data( $person_id ), home_url() . '/#personlogo' );
-			if ( $image_schema ) {
-				$rtn_data['image'] = $image_schema;
-				$rtn_data['logo']  = array( '@id' => home_url() . '/#personlogo' );
+			if ( -1 === $person_id ) {
+				// Manually added Person's name.
+				$rtn_data['name'] = $aioseop_options['aiosp_schema_person_manual_name'];
+
+				// Handle Logo/Image.
+				$image_data   = wp_parse_args( array( 'url' => $aioseop_options['aiosp_schema_person_manual_image'] ), $this->get_image_data_defaults() );
+				$image_schema = $this->prepare_image( $image_data, home_url() . '/#personlogo' );
+				if ( $image_schema ) {
+					$rtn_data['image'] = $image_schema;
+					$rtn_data['logo']  = array( '@id' => home_url() . '/#personlogo' );
+				}
+			} else {
+				// User's Display Name.
+				$rtn_data['name']   = get_the_author_meta( 'display_name', $person_id );
+
+				// Social links from user profile.
+				$rtn_data['sameAs'] = $this->get_user_social_profile_links( $person_id );
+
+				// Handle Logo/Image for retrieving gravatar and image schema.
+				$image_schema = $this->prepare_image( $this->get_user_image_data( $person_id ), home_url() . '/#personlogo' );
+				if ( $image_schema ) {
+					$rtn_data['image'] = $image_schema;
+					$rtn_data['logo']  = array( '@id' => home_url() . '/#personlogo' );
+				}
 			}
 		} else {
 			// Get Name from General > Schema Settings > Organization Name, and fallback on WP's Site Name.


### PR DESCRIPTION
Issue #2792

## Proposed changes

Add the options to manually enter the Schema Person's name and image.

## Types of changes

What types of changes does your code introduce?
_Delete those that don't apply_

- New feature (non-breaking change which adds functionality)
- Improves existing functionality
- Improves existing code

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. If creating a separate issue for an item, link to the issue # at the end of the line._

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [x] I have added necessary documentation.

## Testing instructions

1. Go to AIOSEOP General Settings.
2. Enable Schema Markup.
3. Set 'Organization or Person' to Person.
4. Set Person's Username to Manually Entered.
5. Manually add name to Person's Name, and add image to Person's Image.
6. Go to front end, and Inspect code and search head for `<script type="application/ld+json" class="aioseop-schema">`.

Schema should be using person's name and image.

## Further comments

Improved schema person to use first admin user if no username is selected.
