### PR TITLE
Only show Welcome Screen on major version updates

### DIFF
--- a/admin/display/welcome.php
+++ b/admin/display/welcome.php
@@ -106,7 +106,8 @@ if ( ! class_exists( 'aioseop_welcome' ) ) {
 				return;
 			}
 
-			if ( ( AIOSEOP_VERSION === $seen ) || ( true !== $activate ) ) {
+			// Compare the major versions so we don't show the welcome screen on minor versions.
+			if ( ( get_major_version( AIOSEOP_VERSION ) === get_major_version( $seen ) ) || ( true !== $activate ) ) {
 				return;
 			}
 

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -1401,3 +1401,31 @@ if ( ! function_exists( 'aioseop_is_woocommerce_active' ) ) {
 		return class_exists( 'woocommerce' );
 	}
 }
+
+	/**
+	* Gets the major version of a sementic plugin version.
+	* 
+	* @param string $version 
+	* 
+	* @since 3.2.8
+	* @return string
+	*/
+	public static function get_major_version( $version ){
+
+	if( !strpos( $version, '.' ) ){
+		// No period. Return version which should just look like "x". 
+		return $version;
+	}
+	$offset1 = strpos( $version, '.'); // Location of first period.
+
+	if ( !strpos( $version, '.', $offset1 + 1) ){
+		// No second period. Return version which should just look like "x.y".
+		return $version;
+	}
+	
+	// If we get here, there's at least an "x.y.z".
+	$offset2 = strpos( $version, '.', $offset1 + 1); // Location of second period.
+	$major_version = substr( $version, 0, $offset2);
+
+	return $major_version;
+}

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -1410,7 +1410,7 @@ if ( ! function_exists( 'aioseop_is_woocommerce_active' ) ) {
 	* @since 3.2.8
 	* @return string
 	*/
-	public static function get_major_version( $version ){
+	function get_major_version( $version ){
 
 	if( !strpos( $version, '.' ) ){
 		// No period. Return version which should just look like "x". 

--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -1402,30 +1402,30 @@ if ( ! function_exists( 'aioseop_is_woocommerce_active' ) ) {
 	}
 }
 
-	/**
-	* Gets the major version of a sementic plugin version.
-	* 
-	* @param string $version 
-	* 
-	* @since 3.2.8
-	* @return string
-	*/
-	function get_major_version( $version ){
+/**
+ * Gets the major version of a sementic plugin version.
+ *
+ * @since 3.2.8
+ *
+ * @param string $version
+ * @return string
+ */
+function get_major_version( $version ) {
 
-	if( !strpos( $version, '.' ) ){
-		// No period. Return version which should just look like "x". 
+	if ( ! strpos( $version, '.' ) ) {
+		// No period. Return version which should just look like "x".
 		return $version;
 	}
-	$offset1 = strpos( $version, '.'); // Location of first period.
+	$offset1 = strpos( $version, '.' ); // Location of first period.
 
-	if ( !strpos( $version, '.', $offset1 + 1) ){
+	if ( ! strpos( $version, '.', $offset1 + 1 ) ) {
 		// No second period. Return version which should just look like "x.y".
 		return $version;
 	}
-	
+
 	// If we get here, there's at least an "x.y.z".
-	$offset2 = strpos( $version, '.', $offset1 + 1); // Location of second period.
-	$major_version = substr( $version, 0, $offset2);
+	$offset2       = strpos( $version, '.', $offset1 + 1 ); // Location of second period.
+	$major_version = substr( $version, 0, $offset2 );
 
 	return $major_version;
 }

--- a/inc/aiosp_common.php
+++ b/inc/aiosp_common.php
@@ -488,32 +488,4 @@ class aiosp_common {
 
 		return false;
 	}
-	
-	/**
-	* Gets the major version of a sementic plugin version.
-	* 
-	* @param string $version 
-	* 
-	* @since 3.2.8
-	* @return string
-	*/
-	public static function get_major_version( $version ){
-
-	if( !strpos( $version, '.' ) ){
-		// No period. Return version which should just look like "x". 
-		return $version;
-	}
-	$offset1 = strpos( $version, '.'); // Location of first period.
-
-	if ( !strpos( $version, '.', $offset1 + 1) ){
-		// No second period. Return version which should just look like "x.y".
-		return $version;
-	}
-	
-	// If we get here, there's at least an "x.y.z".
-	$offset2 = strpos( $version, '.', $offset1 + 1); // Location of second period.
-	$major_version = substr( $version, 0, $offset2);
-
-	return $major_version;
-}
 }

--- a/inc/aiosp_common.php
+++ b/inc/aiosp_common.php
@@ -488,4 +488,32 @@ class aiosp_common {
 
 		return false;
 	}
+	
+	/**
+	* Gets the major version of a sementic plugin version.
+	* 
+	* @param string $version 
+	* 
+	* @since 3.2.8
+	* @return string
+	*/
+	public static function get_major_version( $version ){
+
+	if( !strpos( $version, '.' ) ){
+		// No period. Return version which should just look like "x". 
+		return $version;
+	}
+	$offset1 = strpos( $version, '.'); // Location of first period.
+
+	if ( !strpos( $version, '.', $offset1 + 1) ){
+		// No second period. Return version which should just look like "x.y".
+		return $version;
+	}
+	
+	// If we get here, there's at least an "x.y.z".
+	$offset2 = strpos( $version, '.', $offset1 + 1); // Location of second period.
+	$major_version = substr( $version, 0, $offset2);
+
+	return $major_version;
+}
 }


### PR DESCRIPTION
Issue #2662

## Proposed changes

Currently we show the welcome screen on every update, which can be a bit annoying for some users. This truncates everything except the major version part of a version.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions
- Testing is a bit tricky. You'll need to make sure you can reliably reproduce the welcome screen on demand.
- Open your favorite db tool and in aioseop_options in the options table you should see the latest checked version at the end. This is from our db upgrade code in aioseop_updates_class.php.
-Also look for aioseop_seen_about_page. This is the latest version of the about page someone has seen.
-You can delete or modify these numbers to manipulate your environment.
-1.2.3, 1.2.3.4, 1.2 should all have the same result. If you've seen any of them, you don't need to see it again.
-Make sure nothing breaks it, for instance lots of numbers, few numbers, etc.


## Further comments

Ideally both @EkoJR and @arnaudbroes can do a code review, since if we get this wrong it could be very very annoying.