### PR TITLE
remove anon function for php 5.2 compat #2939

### DIFF
--- a/inc/compatability/compat-gutenberg.php
+++ b/inc/compatability/compat-gutenberg.php
@@ -21,11 +21,20 @@
  *
  * @return void
  */
-function gutenberg_fix_metabox() {
+function aioseop_gutenberg_fix_metabox() {
 	if ( false !== stripos( $_SERVER['HTTP_USER_AGENT'], 'Chrome/77.' ) ) {
-		add_action(
-			'admin_head',
-			static function () {
+		add_action( 'admin_head', 'aioseop_swap_css' );
+	}
+}
+
+/**
+ * Swaps the CSS depending on PHP version
+ *
+ * @since 3.2.9
+ * @return void
+ *
+ */
+function aioseop_swap_css() {
 				global $wp_version;
 
 				// Fix should be included in WP v5.3.
@@ -35,14 +44,11 @@ function gutenberg_fix_metabox() {
 
 				// CSS class renamed from 'editor' to 'block-editor' in WP v5.2.
 				if ( version_compare( $wp_version, '5.2', '<' ) ) {
-					gutenberg_fix_metabox_helper( 'editor-writing-flow' );
+					aioseop_gutenberg_fix_metabox_helper( 'editor-writing-flow' );
 				} elseif ( version_compare( $wp_version, '5.2', '>=' ) ) {
-					gutenberg_fix_metabox_helper( 'block-editor-writing-flow' );
+					aioseop_gutenberg_fix_metabox_helper( 'block-editor-writing-flow' );
 				}
 			}
-		);
-	}
-}
 
 /**
  * The gutenberg_fix_metabox_helper() function.
@@ -55,8 +61,8 @@ function gutenberg_fix_metabox() {
  * @param string $class_name
  * @return void
  */
-function gutenberg_fix_metabox_helper( $class_name ) {
+function aioseop_gutenberg_fix_metabox_helper( $class_name ) {
 	echo '<style>.' . $class_name . ' { height: auto; }</style>';
 }
 
-gutenberg_fix_metabox();
+aioseop_gutenberg_fix_metabox();

--- a/inc/compatability/compat-gutenberg.php
+++ b/inc/compatability/compat-gutenberg.php
@@ -35,20 +35,20 @@ function aioseop_gutenberg_fix_metabox() {
  *
  */
 function aioseop_swap_css() {
-				global $wp_version;
+	global $wp_version;
 
-				// Fix should be included in WP v5.3.
-				if ( ! version_compare( $wp_version, '5.0', '>=' ) && version_compare( $wp_version, '5.3', '<' ) ) {
-					return;
-				}
+	// Fix should be included in WP v5.3.
+	if ( ! version_compare( $wp_version, '5.0', '>=' ) && version_compare( $wp_version, '5.3', '<' ) ) {
+		return;
+	}
 
-				// CSS class renamed from 'editor' to 'block-editor' in WP v5.2.
-				if ( version_compare( $wp_version, '5.2', '<' ) ) {
-					aioseop_gutenberg_fix_metabox_helper( 'editor-writing-flow' );
-				} elseif ( version_compare( $wp_version, '5.2', '>=' ) ) {
-					aioseop_gutenberg_fix_metabox_helper( 'block-editor-writing-flow' );
-				}
-			}
+	// CSS class renamed from 'editor' to 'block-editor' in WP v5.2.
+	if ( version_compare( $wp_version, '5.2', '<' ) ) {
+		aioseop_gutenberg_fix_metabox_helper( 'editor-writing-flow' );
+	} elseif ( version_compare( $wp_version, '5.2', '>=' ) ) {
+		aioseop_gutenberg_fix_metabox_helper( 'block-editor-writing-flow' );
+	}
+}
 
 /**
  * The gutenberg_fix_metabox_helper() function.

--- a/inc/compatability/compat-gutenberg.php
+++ b/inc/compatability/compat-gutenberg.php
@@ -31,8 +31,8 @@ function aioseop_gutenberg_fix_metabox() {
  * Swaps the CSS depending on PHP version
  *
  * @since 3.2.9
- * @return void
  *
+ * @return void
  */
 function aioseop_swap_css() {
 	global $wp_version;


### PR DESCRIPTION
Issue #2939

## Proposed changes

In 3.2.8 we added an anonymous function. This removes that for PHP 5.2 compatibility. 
I've also prefixed the functions.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).
- [ ] I have added necessary documentation, or have created an issue for docs (if appropriate).

## Testing instructions
- First, verify the fatal error in PHP 5.2
- Make sure it's fixed with this patch

Also, we need to make sure the Gutenberg/Chrome fix still works.
- First, verify the bug exists in Chrome 77.
- Test that this patch still fixes it: specifically in PHPs 5.2, 5.3, 7.x, and in WPs 5.1, 5.2.

