### PR TITLE
Replace AJAX constant checks with wp_doing_ajax()

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -486,7 +486,7 @@ if ( ! function_exists( 'aioseop_init_class' ) ) {
 
 		// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 		// add_action( 'admin_init', 'aioseop_review_plugin_notice' );
-		if ( defined( 'DOING_AJAX' ) && ! empty( $_POST ) && ! empty( $_POST['action'] ) && 'aioseop_ajax_scan_header' === $_POST['action'] ) {
+		if ( wp_doing_ajax() && ! empty( $_POST ) && ! empty( $_POST['action'] ) && 'aioseop_ajax_scan_header' === $_POST['action'] ) {
 			remove_action( 'init', array( $aiosp, 'add_hooks' ) );
 			add_action( 'admin_init', 'aioseop_scan_post_header' );
 			// if the action doesn't run -- pdb.

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -109,7 +109,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 				add_action( 'wp', array( $this, 'type_setup' ) );
 			}
 
-			if ( ! is_admin() || defined( 'DOING_AJAX' ) || defined( 'AIOSEOP_UNIT_TESTING' ) ) {
+			if ( ! is_admin() || wp_doing_ajax() || defined( 'AIOSEOP_UNIT_TESTING' ) ) {
 				$this->do_opengraph();
 			}
 			// Set variables after WordPress load.
@@ -1627,7 +1627,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 			) {
 				add_filter( 'language_attributes', array( &$this, 'add_attributes' ) );
 			}
-			if ( ! defined( 'DOING_AJAX' ) ) {
+			if ( ! wp_doing_ajax() ) {
 				add_action( 'aioseop_modules_wp_head', array( &$this, 'add_meta' ), 5 );
 				// Add social meta to AMP plugin.
 				if ( apply_filters( 'aioseop_enable_amp_social_meta', true ) === true ) {


### PR DESCRIPTION
Issue #2411 

## Proposed changes

Now that we don't support WP < 4.7, we can replace the old constant checks with the new (introduced in WP 4.7) wp_doing_ajax().

## Types of changes

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Make sure there are no fatal errors and that the Social Meta module outputs OG markup.
