### PR TITLE
Force manual input for Schema.org Person when > 20 users

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1126,23 +1126,35 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 			),
 		);
 
-		$user_args = array(
-			'role__in' => array(
-				'administrator',
-				'editor',
-				'author',
-			),
-			'orderby'  => 'nicename',
-		);
-		$users     = get_users( $user_args );
+		global $pagenow;
+		if ( 'admin.php' === $pagenow ) {
+			// Person's Username setting.
+			$this->default_options['schema_person_user']['initial_options'] = array(
+				0  => __( '- Select -', 'all-in-one-seo-pack' ),
+				-1 => __( 'Manually Enter', 'all-in-one-seo-pack' ),
+			);
 
-		// Person's Username setting.
-		$this->default_options['schema_person_user']['initial_options'] = array(
-			0  => __( '- Select -', 'all-in-one-seo-pack' ),
-			-1 => __( 'Manually Enter', 'all-in-one-seo-pack' ),
-		);
-		foreach ( $users as $user ) {
-			$this->default_options['schema_person_user']['initial_options'][ $user->ID ] = $user->data->user_nicename . ' (' . $user->data->display_name . ')';
+			global $wpdb;
+			$user_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->users" );
+			if ( 20 < $user_count ) {
+				$this->default_options['schema_person_user']['initial_options'] = array(
+					-1 => __( 'Manually Enter', 'all-in-one-seo-pack' ),
+				);
+			} else {
+				$user_args = array(
+					'role__in' => array(
+						'administrator',
+						'editor',
+						'author',
+					),
+					'orderby'  => 'nicename',
+				);
+				$users     = get_users( $user_args );
+
+				foreach ( $users as $user ) {
+					$this->default_options['schema_person_user']['initial_options'][ $user->ID ] = $user->data->user_nicename . ' (' . $user->data->display_name . ')';
+				}
+			}
 		}
 
 		if ( AIOSEOPPRO ) {

--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -1136,7 +1136,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 
 			global $wpdb;
 			$user_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->users" );
-			if ( 20 < $user_count ) {
+			if ( 50 < $user_count ) {
 				$this->default_options['schema_person_user']['initial_options'] = array(
 					-1 => __( 'Manually Enter', 'all-in-one-seo-pack' ),
 				);


### PR DESCRIPTION
Issue #2937

## Proposed changes

Fixes an issue where a query for the Schema.org markup settings slows down website performance. 
The code for this now only runs when the user is on a plugin page in the admin panel (couldn't limit it to our toplevel page specifically) and when there is a max. of 20 users.

## Types of changes

- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

First, make sure you have 20 users (a few of them Admin, Editor or Author) and then go to the General Settings page and check that the dropdown for Schema.org Person Name is populated with these users.

Then, add another user and make sure that the plugin now only allows manual input.

## Further comments

Obviously, the user treshhold can be changed if needed.