### PR TITLE
Change define constants Name and Version with file data

### DIFF
--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -37,16 +37,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 if ( ! defined( 'AIOSEOPPRO' ) ) {
 	define( 'AIOSEOPPRO', false );
 }
-if ( ! defined( 'AIOSEOP_PLUGIN_NAME' ) ) {
-	if ( ! AIOSEOPPRO ) {
-		define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack' );
-	} else {
-		define( 'AIOSEOP_PLUGIN_NAME', 'All in One SEO Pack Pro' );
-	}
-}
-if ( ! defined( 'AIOSEOP_VERSION' ) ) {
-	define( 'AIOSEOP_VERSION', '3.2.10' );
-}
 
 /*
  * DO NOT EDIT BELOW THIS LINE.
@@ -125,6 +115,55 @@ if ( ! defined( 'WP_PLUGIN_URL' ) ) {
 if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins' );
 }
+
+if ( ! function_exists( 'aioseop_define_constants' ) ) {
+
+	/**
+	 * Define constants from readme file
+	 *
+	 * @since 3.4
+	 *
+	 * @see get_file_data()
+	 * @link https://developer.wordpress.org/reference/functions/get_file_data/
+	 * @link https://hitchhackerguide.com/2011/02/12/get_plugin_data/
+	 */
+	function aioseop_define_constants() {
+
+		// Use get_file_data with this file, and get the plugin's file data with default_headers.
+		$default_headers = array(
+			'Name'       => 'Plugin Name',
+			// 'Slug'       => 'Slug',
+			// 'TextDomain' => 'Text Domain',
+			'Version'    => 'Version',
+		);
+		$plugin_data = get_file_data( __FILE__, $default_headers );
+
+		/**
+		 * AIOSEOP Display Name
+		 *
+		 * @since ?
+		 * @since 3.4 Change to file header data.
+		 *
+		 * @var string $AIOSEOP_PLUGIN_NAME Contains 'All In One SEO Pack'.
+		 */
+		define( 'AIOSEOP_PLUGIN_NAME', $plugin_data['Name'] );
+
+		// define( 'AIOSEOP_PLUGIN_SLUG', $plugin_data['Slug'] );
+
+		// define( 'AIOSEOP_TEXT_DOMAIN', $plugin_data['TextDomain'] );
+
+		/**
+		 * Plugin Version Number
+		 *
+		 * @since ?
+		 * @since 3.4 Change to file header data.
+		 *
+		 * @var string $AIOSEOP_VERSION Contains the plugin's version number. Eg. '3.2.4'
+		 */
+		define( 'AIOSEOP_VERSION', $plugin_data['Version'] );
+	}
+}
+add_action( 'plugins_loaded', 'aioseop_define_constants', 9 );
 
 global $aiosp, $aioseop_options, $aioseop_modules, $aioseop_module_list, $aiosp_activation, $aioseop_mem_limit, $aioseop_get_pages_start, $aioseop_admin_menu;
 $aioseop_get_pages_start = 0;

--- a/all_in_one_seo_pack.php
+++ b/all_in_one_seo_pack.php
@@ -119,7 +119,9 @@ if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
 if ( ! function_exists( 'aioseop_define_constants' ) ) {
 
 	/**
-	 * Define constants from readme file
+	 * Define constants from readme file.
+	 *
+	 * @todo Could potentially have plugin file data define the Slug and Text-Domain.
 	 *
 	 * @since 3.4
 	 *
@@ -131,11 +133,10 @@ if ( ! function_exists( 'aioseop_define_constants' ) ) {
 
 		// Use get_file_data with this file, and get the plugin's file data with default_headers.
 		$default_headers = array(
-			'Name'       => 'Plugin Name',
-			// 'Slug'       => 'Slug',
-			// 'TextDomain' => 'Text Domain',
-			'Version'    => 'Version',
+			'Name'    => 'Plugin Name',
+			'Version' => 'Version',
 		);
+
 		$plugin_data = get_file_data( __FILE__, $default_headers );
 
 		/**
@@ -147,10 +148,6 @@ if ( ! function_exists( 'aioseop_define_constants' ) ) {
 		 * @var string $AIOSEOP_PLUGIN_NAME Contains 'All In One SEO Pack'.
 		 */
 		define( 'AIOSEOP_PLUGIN_NAME', $plugin_data['Name'] );
-
-		// define( 'AIOSEOP_PLUGIN_SLUG', $plugin_data['Slug'] );
-
-		// define( 'AIOSEOP_TEXT_DOMAIN', $plugin_data['TextDomain'] );
 
 		/**
 		 * Plugin Version Number


### PR DESCRIPTION
Issue #2926

## Proposed changes

Refactors how constants `AIOSEOP_VERSION` & `AIOSEOP_PLUGIN_NAME` are defined by using a WP function `get_file_data()` to retrieve plugin details from the file header.

This would eliminate having to edit the version number in more than one area, and isolates changes to the file header.

## Types of changes

What types of changes does your code introduce?

- Improves existing functionality
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

Areas to check version number (& plugin name).

* General Settings page on the right side bar there should be a version number.
* Welcome page should also show a version number.
* Inspect Source on admin side should have scripts loaded with a version number `?v=3.2.1`.

## Further comments

`AIOSEOP_PLUGIN_NAME` was included since data was already available and eliminates having to conditionally define the constant.
