### PR TITLE
Fix PHP warning

### DIFF
--- a/inc/general/aioseop-robots-meta.php
+++ b/inc/general/aioseop-robots-meta.php
@@ -15,6 +15,18 @@
 class AIOSEOP_Robots_Meta {
 
 	/**
+	 * User-defined plugin options.
+	 *
+	 * @var array
+	 */
+	private static $plugin_options;
+
+	public function __construct() {
+		global $aioseop_options;
+		$plugin_options = $aioseop_options;
+	}
+
+	/**
 	 * The get_robots_meta() function.
 	 *
 	 * Returns the noindex & nofollow value for the robots meta tag string.
@@ -125,10 +137,15 @@ class AIOSEOP_Robots_Meta {
 	 * @return string
 	 */
 	private function get_meta_value( $key ) {
-		$requested_page = get_queried_object();
 		$meta           = array();
 		$meta_value     = '';
+		$requested_page = get_queried_object();
 
+		if ( empty( $requested_page ) ) {
+			return $meta_value;
+		}
+
+		// TODO Use $meta_opts when get_current_options() is refactored - #2729.
 		if ( property_exists( $requested_page, 'ID' ) ) {
 			$meta = get_post_meta( $requested_page->ID );
 		}
@@ -227,8 +244,7 @@ class AIOSEOP_Robots_Meta {
 	 * @return bool
 	 */
 	private function is_noindexed_paginated_page( $page_number ) {
-		global $aioseop_options;
-		if ( ! empty( $aioseop_options['aiosp_paginated_noindex'] ) && 1 < $page_number ) {
+		if ( ! empty( $plugin_options['aiosp_paginated_noindex'] ) && 1 < $page_number ) {
 			return true;
 		}
 		return false;
@@ -245,8 +261,7 @@ class AIOSEOP_Robots_Meta {
 	 * @return bool
 	 */
 	private function is_nofollowed_paginated_page( $page_number ) {
-		global $aioseop_options;
-		if ( ! empty( $aioseop_options['aiosp_paginated_nofollow'] ) && 1 < $page_number ) {
+		if ( ! empty( $plugin_options['aiosp_paginated_nofollow'] ) && 1 < $page_number ) {
 			return true;
 		}
 		return false;
@@ -281,14 +296,13 @@ class AIOSEOP_Robots_Meta {
 	 * @return bool
 	 */
 	private function is_noindexed_tax() {
-		global $aioseop_options;
 		if (
-			( is_category() && ! empty( $aioseop_options['aiosp_category_noindex'] ) ) ||
-			( is_date() && ! empty( $aioseop_options['aiosp_archive_date_noindex'] ) ) ||
-			( is_author() && ! empty( $aioseop_options['aiosp_archive_author_noindex'] ) ) ||
-			( is_tag() && ! empty( $aioseop_options['aiosp_tags_noindex'] ) ) ||
-			( is_search() && ! empty( $aioseop_options['aiosp_search_noindex'] ) ) ||
-			( is_404() && ! empty( $aioseop_options['aiosp_404_noindex'] ) ) ||
+			( is_category() && ! empty( $plugin_options['aiosp_category_noindex'] ) ) ||
+			( is_date() && ! empty( $plugin_options['aiosp_archive_date_noindex'] ) ) ||
+			( is_author() && ! empty( $plugin_options['aiosp_archive_author_noindex'] ) ) ||
+			( is_tag() && ! empty( $plugin_options['aiosp_tags_noindex'] ) ) ||
+			( is_search() && ! empty( $plugin_options['aiosp_search_noindex'] ) ) ||
+			( is_404() && ! empty( $plugin_options['aiosp_404_noindex'] ) ) ||
 			( is_tax() && in_array( get_query_var( 'taxonomy' ), $this->get_noindexed_taxonomies() ) )
 		) {
 			return true;
@@ -306,9 +320,8 @@ class AIOSEOP_Robots_Meta {
 	 * @return array
 	 */
 	private function get_noindexed_taxonomies() {
-		global $aioseop_options;
-		if ( isset( $aioseop_options['aiosp_tax_noindex'] ) && ! empty( $aioseop_options['aiosp_tax_noindex'] ) ) {
-			return $aioseop_options['aiosp_tax_noindex'];
+		if ( isset( $plugin_options['aiosp_tax_noindex'] ) && ! empty( $plugin_options['aiosp_tax_noindex'] ) ) {
+			return $plugin_options['aiosp_tax_noindex'];
 		}
 		return array();
 	}
@@ -326,10 +339,9 @@ class AIOSEOP_Robots_Meta {
 	 * @return bool
 	 */
 	private function is_noindexed_singular( $post_type, $post_meta_noindex ) {
-		global $aioseop_options;
 		if ( is_singular() && '' === $post_meta_noindex &&
-			! empty( $aioseop_options['aiosp_cpostnoindex'] ) &&
-			in_array( $post_type, $aioseop_options['aiosp_cpostnoindex'] )
+			! empty( $plugin_options['aiosp_cpostnoindex'] ) &&
+			in_array( $post_type, $plugin_options['aiosp_cpostnoindex'] )
 		) {
 			return true;
 		}
@@ -349,10 +361,9 @@ class AIOSEOP_Robots_Meta {
 	 * @return bool
 	 */
 	private function is_nofollowed_singular( $post_type, $post_meta_follow ) {
-		global $aioseop_options;
 		if ( is_singular() && '' === $post_meta_follow &&
-			! empty( $aioseop_options['aiosp_cpostnofollow'] ) &&
-			in_array( $post_type, $aioseop_options['aiosp_cpostnofollow'] )
+			! empty( $plugin_options['aiosp_cpostnofollow'] ) &&
+			in_array( $post_type, $plugin_options['aiosp_cpostnofollow'] )
 		) {
 			return true;
 		}

--- a/inc/general/aioseop-robots-meta.php
+++ b/inc/general/aioseop-robots-meta.php
@@ -16,6 +16,8 @@ class AIOSEOP_Robots_Meta {
 
 	/**
 	 * User-defined plugin options.
+	 * 
+	 * @since 3.3.1
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
Issue #3014

## Proposed changes

Fix for issue where the paginated homepage (set to show latest posts) doesn't return a queried object for the robots meta code.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. First, create a new website and install All in One SEO Pack v3.3.
2. Create 15 or so posts (use https://github.com/arnaudbroes/endless-post-creator if you're lazy) so that the homepage is paginated and navigate to the second page. Two errors appear.
3. Install the PR and confirm that the issue has been fixed.

## Extra comments

Also replaced `global $aioseop_options` with a class variable to remove a few redundant lines.
