### PR TITLE
Fix broken counter and snippet preview from WP 5.3 and AIOSEOP 3.3

### DIFF
--- a/js/admin/aioseop-count-chars.js
+++ b/js/admin/aioseop-count-chars.js
@@ -6,7 +6,7 @@
  * @since 3.3.0 Full refactoring.
  */
 
-(function($) { // eslint-disable-line max-statements
+jQuery(function($){ // eslint-disable-line max-statements
 
 	"use strict";
 
@@ -359,4 +359,4 @@
 		return true;
 	}
 
-})(jQuery);
+});

--- a/js/admin/aioseop-count-chars.js
+++ b/js/admin/aioseop-count-chars.js
@@ -6,7 +6,7 @@
  * @since 3.3.0 Full refactoring.
  */
 
-jQuery(function($){ // eslint-disable-line max-statements
+(function($) { // eslint-disable-line max-statements
 
 	"use strict";
 
@@ -359,4 +359,4 @@ jQuery(function($){ // eslint-disable-line max-statements
 		return true;
 	}
 
-});
+})(jQuery);

--- a/js/admin/aioseop-count-chars.js
+++ b/js/admin/aioseop-count-chars.js
@@ -6,7 +6,7 @@
  * @since 3.3.0 Full refactoring.
  */
 
-$(function () { // eslint-disable-line max-statements
+jQuery(function($){ // eslint-disable-line max-statements
 
 	"use strict";
 

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -7,7 +7,7 @@
  * @package xregexp
  */
 
-(function($) {
+jQuery(function($){
 
 	"use strict";
 
@@ -180,4 +180,4 @@
 		return textArea.value;
 	}
 
-})(jQuery);
+});

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -6,8 +6,7 @@
  * @package all-in-one-seo-pack
  * @package xregexp
  */
-
-jQuery(function($){
+(function($) {
 
 	"use strict";
 
@@ -180,4 +179,4 @@ jQuery(function($){
 		return textArea.value;
 	}
 
-});
+})(jQuery);

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -7,7 +7,7 @@
  * @package xregexp
  */
 
-$(function () {
+jQuery(function($){
 
 	"use strict";
 

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -6,6 +6,7 @@
  * @package all-in-one-seo-pack
  * @package xregexp
  */
+
 (function($) {
 
 	"use strict";


### PR DESCRIPTION
Issue #3033

## Proposed changes

In 3.3 we refactored the snippet preview and counter javascript code.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.
- [ ] I have added tests that prove my fix is effective/my feature works or have created an issue for it (if appropriate).

## Testing instructions
- Install the latest stable version of All in One SEO Pack (3.3.1.1) and WordPress 5.3. 
- Verify the bug (broken snippet preview and counter)
- Verify this fixes it (clear your cache)