### PR TITLE
Add exclude rule to Grunt and fix remaining errors

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -57,6 +57,7 @@
         <exclude name="WordPress.PHP.StrictComparisons.LooseComparison" />
         <exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found" />
         <exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict" />
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
     </rule>
 
     <rule ref="WordPress-Docs" />
@@ -88,8 +89,6 @@
             <property name="posts_per_page" value="50000" />
         </properties>
     </rule>
-    <rule ref="WordPress.WP.TimezoneChange" />
-
 
     <!--  TODO Prefix globals and hooks.  -->
 <!--    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">-->

--- a/tests/modules/general/test-rewrite-title.php
+++ b/tests/modules/general/test-rewrite-title.php
@@ -110,11 +110,11 @@ class Test_Rewrite_Title extends AIOSEOP_Test_Base {
 	 * @since 3.0
 	 */
 	public function macroProvider() {
-		return [
-			'%site_title% & post'     => [ '%site_title', 'post' ],
-			'%site_title% & category' => [ '%site_title', 'category' ],
-			'%blog_title% & post'     => [ '%blog_title', 'post' ],
-			'%blog_title% & category' => [ '%blog_title', 'category' ],
-		];
+		return array(
+			'%site_title% & post'     => array( '%site_title', 'post' ),
+			'%site_title% & category' => array( '%site_title', 'category' ),
+			'%blog_title% & post'     => array( '%blog_title', 'post' ),
+			'%blog_title% & category' => array( '%blog_title', 'category' ),
+		);
 	}
 }

--- a/tests/modules/general/test-shortcodes-in-description.php
+++ b/tests/modules/general/test-shortcodes-in-description.php
@@ -74,8 +74,8 @@ class Test_Shortcodes_In_Description extends AIOSEOP_Test_Base {
 	 * @since 3.0
 	 */
 	public function conflictingShortcodeProvider() {
-		return [
-			'WooCommerce My Account' => [ '[woocommerce_my_account]' ],
-		];
+		return array(
+			'WooCommerce My Account' => array( '[woocommerce_my_account]' ),
+		);
 	}
 }


### PR DESCRIPTION
Related to issue #3026

## Proposed changes

Excludes `WordPress.DateTime.RestrictedFunctions` until #3026 (**Code Refactor - Replace date() with gmdate() where needed**) can be resolved.

This also fixes the remaining Grunt errors.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Removing old code/functionality

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [x] Travis-ci runs with no errors.

## Testing instructions

None - Intended for Travis CI
