### PR TITLE
Also pass $is_gutenberg along in Open Graph module

### DIFF
--- a/js/admin/aioseop-count-chars.js
+++ b/js/admin/aioseop-count-chars.js
@@ -28,6 +28,7 @@ jQuery(function($){ // eslint-disable-line max-statements
 		currentPage              = aioseopCharacterCounter.currentPage;
 	}
 	else if ('undefined' !== typeof aioseopOGCharacterCounter) {
+		isGutenberg   = aioseopOGCharacterCounter.isGutenberg;
 		pluginDirName = aioseopOGCharacterCounter.pluginDirName;
 		currentPage   = aioseopOGCharacterCounter.currentPage;
 	}
@@ -194,7 +195,9 @@ jQuery(function($){ // eslint-disable-line max-statements
 		switch (inputField.attr('name')) {
 			case 'aiosp_title':
 			case 'aioseop_opengraph_settings_title':
-				counterField.val(+$('#aiosp_snippet_title').parent()[0].innerText.length);
+				if( 'undefined' !== typeof $('#aiosp_snippet_title').parent()[0]) {
+					counterField.val(+$('#aiosp_snippet_title').parent()[0].innerText.length);
+				}
 				break;
 			default:
 				descriptionField = $('[name=aiosp_description]')[0].placeholder;

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1885,7 +1885,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 		 */
 		public function admin_enqueue_scripts( $hook_suffix ) {
 			global $current_screen;
-			
+
 			$is_gutenberg = 'false';
 			if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 				$is_gutenberg = 'true';

--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1884,6 +1884,13 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 		 * @param string $hook_suffix
 		 */
 		public function admin_enqueue_scripts( $hook_suffix ) {
+			global $current_screen;
+			
+			$is_gutenberg = 'false';
+			if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+				$is_gutenberg = 'true';
+			}
+
 			switch ( $hook_suffix ) {
 				case 'term.php':
 					// Legacy code for taxonomy terms until we refactor all title format related code.
@@ -1912,6 +1919,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 					);
 
 					$count_chars_data = array(
+						'isGutenberg'   => $is_gutenberg,
 						'pluginDirName' => AIOSEOP_PLUGIN_DIRNAME,
 						'currentPage'   => $hook_suffix,
 					);


### PR DESCRIPTION
Issue #3046

## Proposed changes

Fixes an issue where the Character Counter code does not know whether the Classic Editor is enabled and defaults to Gutenberg. When the Classic Editor is enabled, the code tries to add the event listeners for Gutenberg. This only happens when SEO for a Post is disabled but Social Meta is enabled.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Install All in One SEO Pack v3.3.2 (latest release) and the Classic Editor.
2. Go to General Settings and disable SEO for Posts (or Pages, doesn't matter).
3. Enable the Social Meta module.
4. Go to a Post (or Page). There should be a console error. Clicking on "Featured Image" should show you a Media Library screen that looks off.
5. Install this PR and check that it fixes both issues.

## Further comments

Grunt will fail for this PR since it lacks the fix/changes we already implemented in the 3.4 branch.