### PR TITLE
Shorten post content before processing description

### DIFF
--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -88,13 +88,13 @@ jQuery(function($){
 
 		if ('false' === isGutenberg) {
 			postTitle   = aioseopStripMarkup($.trim($('#title').val()));
-			postContent = aioseopShortenDescription($('#content_ifr').contents().find('body')[0].innerHTML);
-			postExcerpt = aioseopShortenDescription($.trim($('#excerpt').val()));
+			postContent = aioseopGetDescription($('#content_ifr').contents().find('body')[0].innerHTML);
+			postExcerpt = aioseopGetDescription($.trim($('#excerpt').val()));
 		}
 		else {
 			postTitle   = aioseopStripMarkup($.trim($('#post-title-0').val()));
-			postContent = aioseopShortenDescription(wp.data.select('core/editor').getEditedPostAttribute('content'));
-			postExcerpt = aioseopShortenDescription(wp.data.select('core/editor').getEditedPostAttribute('excerpt'));
+			postContent = aioseopGetDescription(wp.data.select('core/editor').getEditedPostAttribute('content'));
+			postExcerpt = aioseopGetDescription(wp.data.select('core/editor').getEditedPostAttribute('excerpt'));
 		}
 
 		let metaboxTitle       = aioseopStripMarkup($.trim($('input[name="aiosp_title').val()));
@@ -127,15 +127,20 @@ jQuery(function($){
 	}
 
 	/**
-	 * The aioseopShortenDescription() function.
+	 * The aioseopGetDescription() function.
 	 * 
 	 * Shortens the description to max. 160 characters without truncation.
 	 * 
 	 * @since 3.3.0
+	 * @since 3.3.4 Shorten post content to improve performance.
 	 * 
-	 * @param string description 
+	 * @param string postContent
+	 * @return string description
 	 */
-	function aioseopShortenDescription(description) {
+	function aioseopGetDescription(postContent) {
+		// Shorten content first to avoid performance drops.
+		let description = postContent.substring(0, 5000);
+
 		description = aioseopStripMarkup(description);
 		if (160 < description.length) {
 			let excessLength = description.length - 160;


### PR DESCRIPTION
Issue #3050

## Proposed changes

Fixes an issue where the Preview Snippet may hang while long posts being edited. 

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Install the latest version and create a long post with 25,000 or more words.
2. When you edit the content, the page should shortly hang. 
3. Install this PR and confirm this is no longer the case.