### PR TITLE
Remove conditional checks for advanced GA settings in free

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -565,11 +565,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 						'rhs' => '',
 					),
 					'aiosp_ga_advanced_options' => 'on',
-					'aiosp_gtm_container_id'    => array(
-						'lhs' => 'aiosp_gtm_container_id',
-						'op'  => '==',
-						'rhs' => '',
-					),
 				),
 			),
 			'ga_link_attribution'         => array(
@@ -596,11 +591,6 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 						'rhs' => '',
 					),
 					'aiosp_ga_advanced_options' => 'on',
-					'aiosp_gtm_container_id'    => array(
-						'lhs' => 'aiosp_gtm_container_id',
-						'op'  => '==',
-						'rhs' => '',
-					),
 				),
 			),
 			'schema_markup'               => array(


### PR DESCRIPTION
Issue #3056

## Proposed changes

Removes conditional checks for two advanced GA settings in free since the Google Tag Manager field is a Pro feature and thus these conditional checks need to be added through Pro.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

Build this PR together with the one in Pro - https://github.com/semperfiwebdesign/aioseop-pro/pull/575