### PR TITLE
Improve regex pattern to remove new lines

### DIFF
--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -165,7 +165,7 @@ jQuery(function($){
 		// Remove all HTML tags.
 		content = content.replace(/(<[^ >][^>]*>)?/gm, '');
 		// Remove all line breaks.
-		content = content.replace(/\s\s+/g, ' ');
+		content = content.replace(/[\r\n]+/gm, ' ');
 		return aioseopDecodeHtmlEntities(content.trim());
 	}
 


### PR DESCRIPTION
Issue #3023

## Proposed changes

This improves the regex pattern to remove new lines.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- Improves existing code

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Reproduce the original issue as seen here- https://github.com/semperfiwebdesign/all-in-one-seo-pack/issues/3023#issuecomment-558285178. You'll want to add at least 2 paragraphs into the Classic Editor block.
2. Install this PR and see if it fixes it. 

## Further comments

@wpsmort this was rather hard to troubleshoot but I believe the regex pattern wasn't able to filter the new lines that the Classic Editor block uses. 

Also during test, note that the Preview Snippet will only update after you unfocus/leave the Classic Editor block and click anywhere else. This behaviour is normal and expected.