### PR TITLE
Skip adding event listeners for front-end page builders

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -27,7 +27,8 @@
 		"aioseopSetGutenbergEditorEventListener": true,
 		"aioseopSetClassicEditorEventListener": true,
 		"aioseopSetClassicEditorTabSwitchEventListener": true,
-		"aioseopGetClassicEditorContent": true
+		"aioseopGetClassicEditorContent": true,
+		"aioseopEditorUndefined": true
 	},
 	"predef": [
 		"jQuery",

--- a/js/admin/aioseop-admin-functions.js
+++ b/js/admin/aioseop-admin-functions.js
@@ -6,7 +6,9 @@
  * @package all-in-one-seo-pack
  */
 
-(function () {'use strict';}());
+(function () { 'use strict'; }());
+
+var aioseopEditorUndefined = false;
 
 /**
  * Checks whether the Gutenberg Editor is active.
@@ -41,6 +43,10 @@ function aioseopIsVisualTab() {
  * @param string functionName The name of the function that has to be called when the event is triggered.
  */
 function aioseopSetClassicEditorEventListener(functionName) {
+	if ('undefined' === typeof (window._wpLoadBlockEditor)) {
+		aioseopEditorUndefined = true;
+		return;
+	}
 	if (aioseopIsVisualTab()) {
 		setTimeout(function () {
 			tinymce.editors[0].on('KeyUp', function () {

--- a/js/admin/aioseop-admin-functions.js
+++ b/js/admin/aioseop-admin-functions.js
@@ -43,10 +43,6 @@ function aioseopIsVisualTab() {
  * @param string functionName The name of the function that has to be called when the event is triggered.
  */
 function aioseopSetClassicEditorEventListener(functionName) {
-	if ('undefined' === typeof (window._wpLoadBlockEditor)) {
-		aioseopEditorUndefined = true;
-		return;
-	}
 	if (aioseopIsVisualTab()) {
 		setTimeout(function () {
 			tinymce.editors[0].on('KeyUp', function () {
@@ -103,6 +99,10 @@ function aioseopGetClassicEditorContent() {
  * @param functionName The name of the function that needs to be called when the event is triggered.
  */
 function aioseopSetGutenbergEditorEventListener(functionName) {
+	if ('undefined' === typeof (window._wpLoadBlockEditor)) {
+		aioseopEditorUndefined = true;
+		return;
+	}
 	window._wpLoadBlockEditor.then(function () {
 		setTimeout(function () {
 			// https://developer.wordpress.org/block-editor/packages/packages-data/

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -71,6 +71,10 @@ jQuery(function($){
 		let postContent = '';
 		let postExcerpt = '';
 
+		if(aioseopEditorUndefined) {
+			return;
+		}
+		
 		if (!isGutenbergEditor) {
 			postTitle   = aioseopStripMarkup($.trim($('#title').val()));
 			postContent = aioseopGetDescription(aioseopGetClassicEditorContent());

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -71,7 +71,7 @@ jQuery(function($){
 		let postContent = '';
 		let postExcerpt = '';
 
-		if(aioseopEditorUndefined) {
+		if (aioseopEditorUndefined) {
 			return;
 		}
 		


### PR DESCRIPTION
Issue #3076

## Proposed changes

Fixes an issue where the code tries to add event listeners for the Preview Snippet when a front-end page builder is being used (e.g. WPBakery).

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Install the latest version of AIOSEOP and a front-end page builder like WPBakery.
2. Reproduce the issue by toggling the front-end page builder mode and checking for console errors.
3. Install this PR and confirm this fixes the issue both with the Block Editor and Classic Editor.