### PR TITLE
Don't run WooCommerce shortcodes

### DIFF
--- a/inc/aioseop_functions.php
+++ b/inc/aioseop_functions.php
@@ -1274,7 +1274,10 @@ if ( ! function_exists( 'aioseop_get_logo' ) ) {
  */
 function aioseop_do_shortcodes( $content ) {
 	$conflicting_shortcodes = array(
-		'WooCommerce Login' => '[woocommerce_my_account]',
+		'WooCommerce Login'          => '[woocommerce_my_account]',
+		'WooCommerce Checkout'       => '[woocommerce_checkout]',
+		'WooCommerce Order Tracking' => '[woocommerce_order_tracking]',
+		'WooCommerce Cart'           => '[woocommerce_cart]',
 	);
 
 	$rtn_conflict_shortcodes = array();


### PR DESCRIPTION
Issue #3047

## Proposed changes

Adds all major WooCommerce shortcodes to our list of conflicting shortcodes that we should avoid from running in the description/title. This fixes the conflict with the Square for WooCommerce plugin.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

@wpsmort You know what to do since we went over this together.

## Further comments

CI Travis and Grunt checks will fail on this PR since it's not based on 3.4 and that's OK.
