### PR TITLE
Fix nested robots meta when SEO is disabled

### DIFF
--- a/aioseop_class.php
+++ b/aioseop_class.php
@@ -4382,10 +4382,10 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		if ( ! $this->is_page_included() ) {
 
 			$aioseop_robots_meta = new AIOSEOP_Robots_Meta();
-			$robots_meta         = $aioseop_robots_meta->get_robots_meta();
+			$robots_meta         = $aioseop_robots_meta->get_robots_meta_tag();
 
 			if ( ! empty( $robots_meta ) ) {
-				echo sprintf( '<meta name="robots" content="%s"', esc_attr( $robots_meta ) ) . " />\n";
+				echo $robots_meta;
 			}
 
 			if ( ! empty( $old_wp_query ) ) {
@@ -4503,7 +4503,7 @@ class All_in_One_SEO_Pack extends All_in_One_SEO_Pack_Module {
 		}
 
 		$aioseop_robots_meta = new AIOSEOP_Robots_Meta();
-		$robots_meta         = $aioseop_robots_meta->get_robots_meta();
+		$robots_meta         = $aioseop_robots_meta->get_robots_meta_tag();
 
 		if ( ! empty( $robots_meta ) ) {
 			$meta_string .= $robots_meta;

--- a/inc/general/aioseop-robots-meta.php
+++ b/inc/general/aioseop-robots-meta.php
@@ -16,7 +16,7 @@ class AIOSEOP_Robots_Meta {
 
 	/**
 	 * User-defined plugin options.
-	 * 
+	 *
 	 * @since 3.3.1
 	 *
 	 * @var array
@@ -29,9 +29,7 @@ class AIOSEOP_Robots_Meta {
 	}
 
 	/**
-	 * The get_robots_meta() function.
-	 *
-	 * Returns the noindex & nofollow value for the robots meta tag string.
+	 * Returns the robots meta tag string.
 	 *
 	 * @since 2.3.5
 	 * @since 2.3.11.5 Added noindex API filter hook for password protected posts.
@@ -41,7 +39,7 @@ class AIOSEOP_Robots_Meta {
 	 *
 	 * @return string
 	 */
-	public function get_robots_meta() {
+	public function get_robots_meta_tag() {
 		$post_type   = get_post_type();
 		$page_number = aioseop_get_page_number();
 
@@ -55,7 +53,7 @@ class AIOSEOP_Robots_Meta {
 		}
 
 		if ( is_front_page() && 0 === $page_number ) {
-			return $this->get_robots_meta_helper( false, false );
+			return $this->get_robots_meta_tag_helper( false, false );
 		}
 
 		if ( $this->is_static_page() ) {
@@ -80,13 +78,11 @@ class AIOSEOP_Robots_Meta {
 			$nofollow = true;
 		}
 
-		return $this->get_robots_meta_helper( $noindex, $nofollow );
+		return $this->get_robots_meta_tag_helper( $noindex, $nofollow );
 	}
 
 	/**
-	 * The get_robots_meta_helper() function.
-	 *
-	 * Helper function for get_robots_meta().
+	 * Helper function for get_robots_meta_tag().
 	 *
 	 * @since 3.2.0
 	 *
@@ -95,7 +91,7 @@ class AIOSEOP_Robots_Meta {
 	 *
 	 * @return string
 	 */
-	private function get_robots_meta_helper( $noindex, $nofollow ) {
+	private function get_robots_meta_tag_helper( $noindex, $nofollow ) {
 		$index_value  = 'index';
 		$follow_value = 'follow';
 


### PR DESCRIPTION
Issue #3080

## Proposed changes

Fixes a bug where one robots meta tag is nested inside another when SEO for the Post is disabled.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. To reproduce this, disable SEO for a Post and toggle either NOINDEX, NOFOLLOW or both. Check the source code. You'll notice one robots meta tag is nested inside another.

2. Install the PR and confirm the fix.