### PR TITLE
Fix input event bug in IE11

### DIFF
--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -47,7 +47,7 @@ jQuery(function($){
 
 		inputFields.forEach(addEvent);
 		function addEvent(item) {
-			item.on('input', function () {
+			item.on('keyup', function () {
 				aioseopUpdatePreviewSnippet();
 			});
 		}


### PR DESCRIPTION
Issue #3102

## Proposed changes

Fixes a critical bug where IE11 crashes when an input event is triggered. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Reproduce the issue in IE11 by navigating to any Post/Page and trying to type in the editor. The page should immediately freeze up. @wpsmort check in on Team Lead for cross-browser testing tool. Worst case scenario we can do a call and I can show it to you.

2. Install this PR and confirm the fix.
