### PR TITLE
Remove reference to findmyfbid.com from help text

### DIFF
--- a/admin/class-aioseop-helper.php
+++ b/admin/class-aioseop-helper.php
@@ -835,7 +835,7 @@ class AIOSEOP_Helper {
 			'aiosp_opengraph_meta_key'                     => __( 'Enter the name of a custom field (or multiple field names separated by commas) to use that field to specify the Open Graph image on Pages or Posts.', 'all-in-one-seo-pack' ),
 
 			// Facebook Settings.
-			'aiosp_opengraph_key'                          => __( 'Enter your Facebook Admin ID here. You can enter multiple IDs separated by a comma. You can look up your Facebook ID using this tool http://findmyfbid.com/', 'all-in-one-seo-pack' ),
+			'aiosp_opengraph_key'                          => __( 'Enter your Facebook Admin ID here. You can enter multiple IDs separated by a comma.', 'all-in-one-seo-pack' ),
 			'aiosp_opengraph_appid'                        => __( 'Enter your Facebook App ID here. Information about how to get your Facebook App ID can be found at https://developers.facebook.com/docs/apps/register', 'all-in-one-seo-pack' ),
 			'aiosp_opengraph_gen_tags'                     => __( 'Automatically generate article tags for Facebook type article when not provided.', 'all-in-one-seo-pack' ),
 			'aiosp_opengraph_gen_keywords'                 => __( 'Use keywords in generated article tags.', 'all-in-one-seo-pack' ),


### PR DESCRIPTION
Issue #3092

## Proposed changes
This updates the inline help for the Facebook Admin ID option to remove the reference to the extinct site findmyfbid.com.

## Types of changes
- Improves existing code

## Checklist
- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions
Install this code and check the tooltip help for the Facebook Admin ID setting in the Social Meta module.