### PR TITLE
Run preview snippet code after iframe load

### DIFF
--- a/js/admin/aioseop-admin-functions.js
+++ b/js/admin/aioseop-admin-functions.js
@@ -79,13 +79,13 @@ function aioseopSetClassicEditorTabSwitchEventListener(functionName) {
  * Gets the content of the active Classic Editor tab.
  * 
  * @since 3.3.4
+ * @since 3.3.5 Use built-in function tinymce.activeEditor.getContent() to grab content.
  * 
  * @return string The content of the active editor tab.
  */
 function aioseopGetClassicEditorContent() {
 	if (aioseopIsVisualTab()) {
-		//tinymce.activeEditor.getContent();
-		return jQuery('#content_ifr').contents().find('body')[0].innerHTML;
+		return tinymce.activeEditor.getContent({format : 'raw'});
 	}
 	return jQuery('.wp-editor-area').val();
 }

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -21,7 +21,9 @@ jQuery(function($){
 	let skipExcerpt              = aioseop_preview_snippet.skipExcerpt;
 	let isGutenbergEditor        = aioseopIsGutenbergEditor();
 
-	aioseopInitPreviewSnippet();
+	$(window).on("load", function() {
+		aioseopInitPreviewSnippet();
+	});
 
 	/**
 	 * Defines the relevant fields and adds the relevant event listeners based on which editor is active.
@@ -52,10 +54,7 @@ jQuery(function($){
 			});
 		}
 
-		// Run once on page load.
-		timeout = setTimeout(function () {
-			aioseopUpdatePreviewSnippet();
-		}, 1000);
+		aioseopUpdatePreviewSnippet();
 	}
 
 	/**

--- a/js/admin/aioseop-preview-snippet.js
+++ b/js/admin/aioseop-preview-snippet.js
@@ -30,6 +30,7 @@ jQuery(function($){
 	 * 
 	 * @since 3.3.0
 	 * @since 3.3.4 Add support for text tab in Classic Editor.
+	 * @since 3.3.5 Run preview snippet only after Classic Editor content iframe is loaded - #3097.
 	 */
 	function aioseopInitPreviewSnippet() {
 		let inputFields = [aioseopTitle, aioseopDescription];
@@ -39,22 +40,36 @@ jQuery(function($){
 			let postExcerpt = $('#excerpt');
 
 			inputFields.push(docTitle, postExcerpt);
+			aioseopAddPreviewSnippetEventListeners(inputFields)
 
 			aioseopSetClassicEditorTabSwitchEventListener(aioseopUpdatePreviewSnippet);
 			aioseopSetClassicEditorEventListener(aioseopUpdatePreviewSnippet);
+		
+			$('#content_ifr').load(function() {
+				aioseopUpdatePreviewSnippet();
+			});
 		}
 		else {
-			aioseopSetGutenbergEditorEventListener(aioseopUpdatePreviewSnippet);
+			aioseopSetGutenbergEditorEventListener(aioseopUpdatePreviewSnippet);	
+			aioseopAddPreviewSnippetEventListeners(inputFields)	
+			aioseopUpdatePreviewSnippet();
 		}
+	}
 
+	/**
+	 * Adds event listeners to input fields that need to update the preview snippet on change.
+	 * 
+	 * @since 3.3.5
+	 * 
+	 * @param 	Array 	inputFields 	All input fields that need to update the preview snippet on change.
+	 */
+	function aioseopAddPreviewSnippetEventListeners(inputFields) {
 		inputFields.forEach(addEvent);
 		function addEvent(item) {
 			item.on('input', function () {
 				aioseopUpdatePreviewSnippet();
 			});
 		}
-
-		aioseopUpdatePreviewSnippet();
 	}
 
 	/**


### PR DESCRIPTION
Issue #3097

## Proposed changes

This PR fixes an issue where the preview snippet code cannot add the required event listeners on slow computers because the editor isn't fully loaded yet. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

Use these steps to reproduce the issue:

1. Install the latest version of the plugin.
2. Go to the Edit Post screen using Google Chrome. Open the Google Chrome Dev Tools and go to the Performance tab. Click on the gear icon and throttle the network speed to "Slow 3G" and set the CPU speed to "6x slowdown".
3. Reload the page. If the page loaded slow enough, you should see one or two console errors.

Then, install this PR and confirm that the console errors no longer appear and the preview snippet is working fine. Make sure that the preview snippet is working for both the Classic Editor and Gutenberg Editor.