### PR TITLE
Don't generate OG:description from content when setting is disabled 

### DIFF
--- a/modules/aioseop_opengraph.php
+++ b/modules/aioseop_opengraph.php
@@ -1177,7 +1177,7 @@ if ( ! class_exists( 'All_in_One_SEO_Pack_Opengraph' ) ) {
 
 					$description = $post->post_excerpt;
 
-					if ( $this->options['aiosp_opengraph_generate_descriptions'] || empty( $description ) ) {
+					if ( $this->options['aiosp_opengraph_generate_descriptions'] && empty( $description ) ) {
 						if ( ! AIOSEOPPRO || ( AIOSEOPPRO && apply_filters( $this->prefix . 'generate_descriptions_from_content', true, $post ) ) ) {
 							$description = $post->post_content;
 						} else {


### PR DESCRIPTION
Issue #1656

## Proposed changes

Fixes an issue where the OG:description still uses the content when the "Use content for autogenerated OG:descriptions" setting is disabled.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I've selected the appropriate branch (ie x.y rather than master).
- [x] I've created an appropriate title, descriptive of what the PR does.
- [ ] Travis-ci runs with no errors.

## Testing instructions

1. Install the latest version of the plugin, enable the Social Meta menu and make sure the "Use content for autogenerated OG:descriptions" setting is disabled.
2. Create a new post with some content. Check the source code and confirm that the post has an OG:description with the content of the post in it.

Then, install this PR and confirm this is no longer the case and that the setting's value is respected. When the post has an excerpt, it should still have an OG:description like we discussed.